### PR TITLE
75 improve authorization security

### DIFF
--- a/QuolanceAPI.postman_collection.json
+++ b/QuolanceAPI.postman_collection.json
@@ -25,12 +25,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/users",
+							"raw": "http://localhost:8081/api/users",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"users"
@@ -54,12 +54,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/users/forgot-password",
+							"raw": "http://localhost:8081/api/users/forgot-password",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"users",
@@ -84,12 +84,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/users/reset-password",
+							"raw": "http://localhost:8081/api/users/reset-password",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"users",
@@ -114,12 +114,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/users",
+							"raw": "http://localhost:8081/api/users",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"users"
@@ -143,12 +143,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/users/password",
+							"raw": "http://localhost:8081/api/users/password",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"users",
@@ -174,12 +174,12 @@
 							]
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/users/:id/profile-picture",
+							"raw": "http://localhost:8081/api/users/:id/profile-picture",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"users",
@@ -223,12 +223,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/auth/login",
+							"raw": "http://localhost:8081/api/auth/login",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"auth",
@@ -253,12 +253,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/auth/logout",
+							"raw": "http://localhost:8081/api/auth/logout",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"auth",
@@ -279,12 +279,12 @@
 							}
 						],
 						"url": {
-							"raw": "http://localhost:8080/api/auth/me",
+							"raw": "http://localhost:8081/api/auth/me",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"auth",
@@ -296,22 +296,6 @@
 				},
 				{
 					"name": "csrf",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": ""
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "AdminUsersController",
-			"item": [
-				{
-					"name": "getUsers",
 					"request": {
 						"method": "GET",
 						"header": [],
@@ -336,7 +320,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"tags\": [\n    \"JAVA\"\n  ],\n  \"projectDescription\": \"string\",\n  \"clientId\": 1\n}",
+							"raw": "{\n  \"tags\": [\n    \"JAVA\"\n  ],\n  \"projectDescription\": \"string\"\n  }",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -344,12 +328,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/client/create-project",
+							"raw": "http://localhost:8081/api/client/create-project",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"client",
@@ -375,12 +359,12 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8080/api/client/projects/client/1",
+							"raw": "http://localhost:8081/api/client/projects/client/1",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"client",
@@ -398,16 +382,15 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8080/api/client/1/projects",
+							"raw": "http://localhost:8081/api/client/projects",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"client",
-								"1",
 								"projects"
 							]
 						}
@@ -426,7 +409,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"applicationStatus\": \"IN_PROGRESS\",\n  \"projectId\": 1,\n  \"userId\": 2\n}",
+							"raw": "{\n  \"applicationStatus\": \"IN_PROGRESS\",\n  \"projectId\": 1\n  }",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -434,12 +417,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/freelancer/submit-application",
+							"raw": "http://localhost:8081/api/freelancer/submit-application",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"freelancer",
@@ -455,16 +438,15 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8080/api/freelancer/2/applications",
+							"raw": "http://localhost:8081/api/freelancer/applications",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"freelancer",
-								"2",
 								"applications"
 							]
 						}
@@ -477,12 +459,12 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8080/api/freelancer/projects",
+							"raw": "http://localhost:8081/api/freelancer/projects",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"freelancer",
@@ -498,12 +480,12 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8080/api/freelancer/projects/2",
+							"raw": "http://localhost:8081/api/freelancer/projects/2",
 							"protocol": "http",
 							"host": [
 								"localhost"
 							],
-							"port": "8080",
+							"port": "8081",
 							"path": [
 								"api",
 								"freelancer",

--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
@@ -1,17 +1,10 @@
 package com.quolance.quolance_api.configs;
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
-import com.quolance.quolance_api.configs.ApplicationProperties;
 import com.quolance.quolance_api.services.auth.OAuth2LoginSuccessHandlerImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,8 +21,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.authentication.switchuser.SwitchUserFilter;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
@@ -40,6 +31,13 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
 @Configuration
 @EnableMethodSecurity
 @RequiredArgsConstructor
@@ -47,8 +45,6 @@ public class SecurityConfiguration {
 
     private static final String[] WHITE_LIST_URL = {
             "/api/auth/**",
-            "/api/client/**",
-            "/api/freelancer/**",
             "http://localhost:8080/api/**",
             "http://localhost:8080/api/users/**",
             "/v2/api-docs",
@@ -80,6 +76,8 @@ public class SecurityConfiguration {
                     .requestMatchers(antMatcher(HttpMethod.GET, "/api/auth/csrf")).permitAll()
                     .requestMatchers(antMatcher(HttpMethod.GET, "/api/auth/impersonate")).hasRole("ADMIN")
                     .requestMatchers(antMatcher(HttpMethod.GET, "/api/auth/impersonate/exit")).hasRole("PREVIOUS_ADMINISTRATOR")
+                    .requestMatchers(antMatcher("/api/client/**")).hasRole("CLIENT")
+                    .requestMatchers(antMatcher("/api/freelancer/**")).hasRole("FREELANCER")
                     .anyRequest().authenticated();
         });
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
@@ -26,7 +26,8 @@ public class ClientController {
             description = "Create a project by passing a project dto"
     )
     public ResponseEntity<ProjectDto> createProject(@RequestBody ProjectDto projectDto) {
-        ProjectDto project = clientService.createProject(projectDto);
+        User client = SecurityUtil.getAuthenticatedUser();
+        ProjectDto project = clientService.createProject(projectDto, client);
         return ResponseEntity.ok(project);
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
@@ -3,7 +3,6 @@ package com.quolance.quolance_api.controllers;
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
 import com.quolance.quolance_api.entities.User;
-import com.quolance.quolance_api.services.ApplicationService;
 import com.quolance.quolance_api.services.ClientService;
 import com.quolance.quolance_api.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,7 +17,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ClientController {
     private final ClientService clientService;
-    private final ApplicationService applicationService;
 
     @PostMapping("/create-project")
     @Operation(
@@ -32,10 +30,7 @@ public class ClientController {
     }
 
     @GetMapping("/projects")
-    @Operation(
-            summary = "Get all projects of a client",
-            description = "Get all projects of a client by passing the client ID"
-    )
+    @Operation(summary = "Get all projects of a client")
     public ResponseEntity<List<ProjectDto>> getAllMyProjects() {
         User user = SecurityUtil.getAuthenticatedUser();
         List<ProjectDto> projects = clientService.getProjectsByClientId(user.getId());
@@ -48,7 +43,8 @@ public class ClientController {
             description = "Get all applications on a project by passing the project ID"
     )
     public ResponseEntity<List<ApplicationDto>> getAllApplicationsToProject(@PathVariable(name = "projectId") Long projectId) {
-        List<ApplicationDto> applications = applicationService.getApplicationsByProjectId(projectId);
+        User user = SecurityUtil.getAuthenticatedUser();
+        List<ApplicationDto> applications = clientService.getApplicationsByProjectId(projectId, user.getId());
         return ResponseEntity.ok(applications);
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
@@ -32,8 +32,8 @@ public class ClientController {
     @GetMapping("/projects")
     @Operation(summary = "Get all projects of a client")
     public ResponseEntity<List<ProjectDto>> getAllMyProjects() {
-        User user = SecurityUtil.getAuthenticatedUser();
-        List<ProjectDto> projects = clientService.getProjectsByClientId(user.getId());
+        User client = SecurityUtil.getAuthenticatedUser();
+        List<ProjectDto> projects = clientService.getProjectsByClientId(client.getId());
         return ResponseEntity.ok(projects);
     }
 
@@ -43,8 +43,8 @@ public class ClientController {
             description = "Get all applications on a project by passing the project ID"
     )
     public ResponseEntity<List<ApplicationDto>> getAllApplicationsToProject(@PathVariable(name = "projectId") Long projectId) {
-        User user = SecurityUtil.getAuthenticatedUser();
-        List<ApplicationDto> applications = clientService.getApplicationsByProjectId(projectId, user.getId());
+        User client = SecurityUtil.getAuthenticatedUser();
+        List<ApplicationDto> applications = clientService.getApplicationsByProjectId(projectId, client.getId());
         return ResponseEntity.ok(applications);
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
@@ -2,8 +2,10 @@ package com.quolance.quolance_api.controllers;
 
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.services.ApplicationService;
 import com.quolance.quolance_api.services.ClientService;
+import com.quolance.quolance_api.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,13 +30,14 @@ public class ClientController {
         return ResponseEntity.ok(project);
     }
 
-    @GetMapping("/{clientId}/projects")
+    @GetMapping("/projects")
     @Operation(
             summary = "Get all projects of a client",
             description = "Get all projects of a client by passing the client ID"
     )
-    public ResponseEntity<List<ProjectDto>> getAllMyProjects(@PathVariable(name = "clientId") Long clientId) {
-        List<ProjectDto> projects = clientService.getMyProjects(clientId);
+    public ResponseEntity<List<ProjectDto>> getAllMyProjects() {
+        User user = SecurityUtil.getAuthenticatedUser();
+        List<ProjectDto> projects = clientService.getProjectsByClientId(user.getId());
         return ResponseEntity.ok(projects);
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FreelancerController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FreelancerController.java
@@ -2,8 +2,9 @@ package com.quolance.quolance_api.controllers;
 
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.services.FreelancerService;
-import com.quolance.quolance_api.services.ProjectService;
+import com.quolance.quolance_api.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,15 +17,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FreelancerController {
     private final FreelancerService freelancerService;
-    private final ProjectService projectService;
 
     @PostMapping("/submit-application")
     @Operation(
             summary = "Create a new application on a project.",
             description = "Create a new application on a project by passing an ApplicationDto"
     )
-    public ResponseEntity<ApplicationDto> createProject(@RequestBody ApplicationDto applicationDto) {
-        ApplicationDto application = freelancerService.submitApplication(applicationDto);
+    public ResponseEntity<ApplicationDto> applyToProject(@RequestBody ApplicationDto applicationDto) {
+        User freelancer = SecurityUtil.getAuthenticatedUser();
+        ApplicationDto application = freelancerService.submitApplication(applicationDto, freelancer);
         return ResponseEntity.ok(application);
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FreelancerController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FreelancerController.java
@@ -29,21 +29,16 @@ public class FreelancerController {
         return ResponseEntity.ok(application);
     }
 
-    @GetMapping("/{freelancerId}/applications")
-    @Operation(
-            summary = "View all the application of a freelancer.",
-            description = "View all the application of a freelancer by passing the freelancer id."
-    )
-    public ResponseEntity<List<ApplicationDto>> getAllMyApplications(@PathVariable(name = "freelancerId") Long freelancerId) {
-        List<ApplicationDto> applications = freelancerService.getMyApplications(freelancerId);
+    @GetMapping("/applications")
+    @Operation(summary = "View all the application of a freelancer.")
+    public ResponseEntity<List<ApplicationDto>> getAllMyApplications() {
+        User freelancer = SecurityUtil.getAuthenticatedUser();
+        List<ApplicationDto> applications = freelancerService.getMyApplications(freelancer.getId());
         return ResponseEntity.ok(applications);
     }
 
     @GetMapping("/projects")
-    @Operation(
-            summary = "View all projects.",
-            description = "View all projects."
-    )
+    @Operation(summary = "View all projects.")
     public ResponseEntity<List<ProjectDto>> getAllProjects() {
         List<ProjectDto> projects = freelancerService.getAllAvailableProjects();
         return ResponseEntity.ok(projects);

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/UsersController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/UsersController.java
@@ -2,7 +2,9 @@ package com.quolance.quolance_api.controllers;
 
 import com.quolance.quolance_api.configs.ApplicationProperties;
 import com.quolance.quolance_api.dtos.*;
+import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.services.UserService;
+import com.quolance.quolance_api.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -65,8 +67,9 @@ public class UsersController {
             summary = "Update an existing user",
             description = "Update an existing user by passing the UpdateUserRequestDto. Only allowed to self.")
     public ResponseEntity<UserResponseDto> update(@Valid @RequestBody UpdateUserRequestDto request) {
-        UserResponseDto user = userService.updateUser(request);
-        return ResponseEntity.ok(user);
+        User user = SecurityUtil.getAuthenticatedUser();
+        UserResponseDto userResponse = userService.updateUser(request, user);
+        return ResponseEntity.ok(userResponse);
     }
 
     @PatchMapping("/password")
@@ -75,8 +78,9 @@ public class UsersController {
             description = "Update the password of an existing user by passing the UpdateUserPasswordRequestDto. Only allowed with the correct old password.")
     public ResponseEntity<UserResponseDto> updatePassword(
             @Valid @RequestBody UpdateUserPasswordRequestDto requestDTO) {
-        UserResponseDto user = userService.updatePassword(requestDTO);
-        return ResponseEntity.ok(user);
+        User user = SecurityUtil.getAuthenticatedUser();
+        UserResponseDto userResponseDto = userService.updatePassword(requestDTO, user);
+        return ResponseEntity.ok(userResponseDto);
     }
 
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/ApplicationDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/ApplicationDto.java
@@ -22,8 +22,8 @@ public class ApplicationDto {
     @JsonProperty("projectId")
     private Long projectId;
 
-    @JsonProperty("userId")
-    private Long userId;
+    @JsonProperty("freelancerId")
+    private Long freelancerId;
 
     public static Application toEntity(ApplicationDto applicationDto) {
         return Application.builder()
@@ -36,7 +36,7 @@ public class ApplicationDto {
                 .id(application.getId())
                 .status(application.getStatus())
                 .projectId(application.getProject() != null ? application.getProject().getId() : null)
-                .userId(application.getFreelancer() != null ? application.getFreelancer().getId() : null)
+                .freelancerId(application.getFreelancer() != null ? application.getFreelancer().getId() : null)
                 .build();
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/ClientService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/ClientService.java
@@ -2,11 +2,12 @@ package com.quolance.quolance_api.services;
 
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.entities.User;
 
 import java.util.List;
 
 public interface ClientService {
-    ProjectDto createProject(ProjectDto projectDto);
+    ProjectDto createProject(ProjectDto projectDto, User client);
 
     List<ProjectDto> getProjectsByClientId(Long clientId);
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/ClientService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/ClientService.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface ClientService {
     ProjectDto createProject(ProjectDto projectDto);
 
-    List<ProjectDto> getMyProjects(Long clientId);
+    List<ProjectDto> getProjectsByClientId(Long clientId);
 
     List<ApplicationDto> getApplicationsToMyProject(Long projectId);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/ClientService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/ClientService.java
@@ -11,5 +11,5 @@ public interface ClientService {
 
     List<ProjectDto> getProjectsByClientId(Long clientId);
 
-    List<ApplicationDto> getApplicationsToMyProject(Long projectId);
+    List<ApplicationDto> getApplicationsByProjectId(Long projectId, Long clientId);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/FreelancerService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/FreelancerService.java
@@ -2,12 +2,13 @@ package com.quolance.quolance_api.services;
 
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.entities.User;
 
 import java.util.List;
 
 public interface FreelancerService {
 
-    ApplicationDto submitApplication(ApplicationDto applicationDto);
+    ApplicationDto submitApplication(ApplicationDto applicationDto, User freelancer);
     List<ApplicationDto> getMyApplications(Long freelancerId);
 
     List<ProjectDto> getAllAvailableProjects();

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
@@ -1,6 +1,7 @@
 package com.quolance.quolance_api.services;
 
 
+import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
 import com.quolance.quolance_api.entities.Project;
 
@@ -13,4 +14,6 @@ public interface ProjectService {
     List<ProjectDto> getAllProjects();
     ProjectDto getProjectById(Long id);
     Optional<Project> getProjectEntityById(Long id);
+
+    List<ApplicationDto> getApplicationsToProject(Long projectId);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/UserService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/UserService.java
@@ -21,7 +21,7 @@ public interface UserService {
 
     void resetPassword(UpdateUserPasswordRequestDto request);
 
-    UserResponseDto updateUser(UpdateUserRequestDto request);
+    UserResponseDto updateUser(UpdateUserRequestDto request, User user);
 
-    UserResponseDto updatePassword(UpdateUserPasswordRequestDto request);
+    UserResponseDto updatePassword(UpdateUserPasswordRequestDto request, User user);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ClientServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ClientServiceImpl.java
@@ -17,12 +17,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ClientServiceImpl implements ClientService {
     private final ProjectService projectService;
-    private final UserService userService;
     private final ApplicationService applicationService;
 
     @Override
-    public ProjectDto createProject(ProjectDto projectDto) {
-        User client = userService.findById(projectDto.getClientId()).orElseThrow();
+    public ProjectDto createProject(ProjectDto projectDto, User client) {
         Project projectToSave = ProjectDto.toEntity(projectDto);
         projectToSave.setClient(client);
         ProjectDto savedProject = projectService.createProject(projectToSave);

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ClientServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ClientServiceImpl.java
@@ -30,7 +30,7 @@ public class ClientServiceImpl implements ClientService {
     }
 
     @Override
-    public List<ProjectDto> getMyProjects(Long clientId) {
+    public List<ProjectDto> getProjectsByClientId(Long clientId) {
         List<ProjectDto> projects = projectService.getProjectsByClientId(clientId);
         return projects;
     }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ClientServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ClientServiceImpl.java
@@ -4,10 +4,8 @@ import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
 import com.quolance.quolance_api.entities.Project;
 import com.quolance.quolance_api.entities.User;
-import com.quolance.quolance_api.services.ApplicationService;
 import com.quolance.quolance_api.services.ClientService;
 import com.quolance.quolance_api.services.ProjectService;
-import com.quolance.quolance_api.services.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,7 +15,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ClientServiceImpl implements ClientService {
     private final ProjectService projectService;
-    private final ApplicationService applicationService;
 
     @Override
     public ProjectDto createProject(ProjectDto projectDto, User client) {
@@ -34,8 +31,13 @@ public class ClientServiceImpl implements ClientService {
     }
 
     @Override
-    public List<ApplicationDto> getApplicationsToMyProject(Long projectId) {
-        List<ApplicationDto> applications = applicationService.getApplicationsByProjectId(projectId);
-        return applications;
+    public List<ApplicationDto> getApplicationsByProjectId(Long projectId, Long clientId) {
+        List<ProjectDto> clientProjects = getProjectsByClientId(clientId);
+        for (ProjectDto project : clientProjects) {
+            if (project.getId().equals(projectId)) {
+                return projectService.getApplicationsToProject(projectId);
+            }
+        }
+        return List.of();
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/FreelancerServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/FreelancerServiceImpl.java
@@ -16,13 +16,11 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class FreelancerServiceImpl implements FreelancerService {
-    private final UserService userService;
     private final ApplicationService applicationService;
     private final ProjectService projectService;
 
     @Override
-    public ApplicationDto submitApplication(ApplicationDto applicationDto) {
-        User freelancer = userService.findById(applicationDto.getUserId()).orElseThrow();
+    public ApplicationDto submitApplication(ApplicationDto applicationDto, User freelancer) {
         Project project = projectService.getProjectEntityById(applicationDto.getProjectId()).orElseThrow();
 
         Application applicationToSave = ApplicationDto.toEntity(applicationDto);

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
@@ -1,8 +1,10 @@
 package com.quolance.quolance_api.services.impl;
 
+import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
 import com.quolance.quolance_api.entities.Project;
 import com.quolance.quolance_api.repositories.ProjectRepository;
+import com.quolance.quolance_api.services.ApplicationService;
 import com.quolance.quolance_api.services.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ProjectServiceImpl implements ProjectService {
     private final ProjectRepository projectRepository;
+    private final ApplicationService applicationService;
 
     @Override
     public ProjectDto createProject(Project project) {
@@ -44,5 +47,10 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     public Optional<Project> getProjectEntityById(Long id) {
         return projectRepository.findById(id);
+    }
+
+    @Override
+    public List<ApplicationDto> getApplicationsToProject(Long projectId) {
+        return applicationService.getApplicationsByProjectId(projectId);
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/UserServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/UserServiceImpl.java
@@ -14,7 +14,6 @@ import com.quolance.quolance_api.repositories.UserRepository;
 import com.quolance.quolance_api.repositories.VerificationCodeRepository;
 import com.quolance.quolance_api.services.UserService;
 import com.quolance.quolance_api.util.exceptions.ApiException;
-import com.quolance.quolance_api.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.jobrunr.scheduling.BackgroundJobRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -98,9 +97,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public UserResponseDto updateUser(UpdateUserRequestDto request) {
-        User user = SecurityUtil.getAuthenticatedUser();
-        user = userRepository.getReferenceById(user.getId());
+    public UserResponseDto updateUser(UpdateUserRequestDto request, User user) {
         user.update(request);
         user = userRepository.save(user);
         return new UserResponseDto(user);
@@ -108,8 +105,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public UserResponseDto updatePassword(UpdateUserPasswordRequestDto request) {
-        User user = SecurityUtil.getAuthenticatedUser();
+    public UserResponseDto updatePassword(UpdateUserPasswordRequestDto request, User user) {
         if (user.getPassword() != null && !passwordEncoder.matches(request.getOldPassword(), user.getPassword())) {
             throw ApiException.builder().status(400).message("Wrong password").build();
         }


### PR DESCRIPTION
- Client and freelancer endpoints need authentication, removed from whitelist.
- Requests are made according to the authenticated user, not the id of users in the bodies or parameters of requests.
For example, if a freelancer wants to see all his applications, the id is not passed anywhere, rather we use `SecurityUtil.getAuthenticated()`.
Closes #75 