### PR TITLE
29 BE Admin can create admin

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
@@ -72,6 +72,7 @@ public class SecurityConfiguration {
                     .requestMatchers(antMatcher(HttpMethod.GET, "/api/users/verify-email")).permitAll()
                     .requestMatchers(antMatcher(HttpMethod.POST, "/api/users/forgot-password")).permitAll()
                     .requestMatchers(antMatcher(HttpMethod.PATCH, "/api/users/reset-password")).permitAll()
+                    .requestMatchers(antMatcher(HttpMethod.POST, "/api/users/admin")).hasRole("ADMIN")
                     .requestMatchers(antMatcher(HttpMethod.POST, "/api/auth/login")).permitAll()
                     .requestMatchers(antMatcher(HttpMethod.GET, "/api/auth/csrf")).permitAll()
                     .requestMatchers(antMatcher(HttpMethod.GET, "/api/auth/impersonate")).hasRole("ADMIN")

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/UsersController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/UsersController.java
@@ -36,6 +36,16 @@ public class UsersController {
         return ResponseEntity.ok(user);
     }
 
+    @PostMapping("/admin")
+    @Operation(
+            summary = "Create an admin",
+            description = "Create a new user with admin role. Only available to authenticated admins."
+    )
+    @ApiResponse(responseCode = "200", description = "Admin created successfully")
+    public ResponseEntity<UserResponseDto> createAdmin(@Valid @RequestBody CreateAdminRequestDto request) {
+        UserResponseDto user = userService.createAdmin(request);
+        return ResponseEntity.ok(user);
+    }
     @GetMapping("/verify-email")
     @Operation(
             summary = "Verify the email of the user",
@@ -75,7 +85,7 @@ public class UsersController {
     @PatchMapping("/password")
     @Operation(
             summary = "Update the password of an existing user",
-            description = "Update the password of an existing user by passing the UpdateUserPasswordRequestDto. Only allowed with the correct old password.")
+            description = "Update the password of an existing user by passing the UpdateUserPasswordRequestDto. Only allowed with the correct old password. The field passwordResetToken is not required.")
     public ResponseEntity<UserResponseDto> updatePassword(
             @Valid @RequestBody UpdateUserPasswordRequestDto requestDTO) {
         User user = SecurityUtil.getAuthenticatedUser();

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/CreateAdminRequestDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/CreateAdminRequestDto.java
@@ -1,0 +1,20 @@
+package com.quolance.quolance_api.dtos;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+public class CreateAdminRequestDto {
+    @Email
+    private String email;
+    @NotNull
+    @Length(min = 8)
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).*$", message = "must contain at least one uppercase letter, one lowercase letter, and one digit.")
+    private String temporaryPassword;
+    private String passwordConfirmation;
+    private String firstName;
+    private String lastName;
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/User.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/User.java
@@ -1,5 +1,6 @@
 package com.quolance.quolance_api.entities;
 
+import com.quolance.quolance_api.dtos.CreateAdminRequestDto;
 import com.quolance.quolance_api.dtos.CreateUserRequestDto;
 import com.quolance.quolance_api.dtos.UpdateUserRequestDto;
 import com.quolance.quolance_api.entities.enums.Role;
@@ -79,6 +80,19 @@ public class User extends AbstractEntity implements UserDetails {
         this.lastName = data.getLastName();
         this.role = Role.valueOf(data.getRole());
     }
+
+    /**
+     * Constructor to create an Admin User from a CreateAdminRequestDto.
+     */
+    public User(CreateAdminRequestDto data) {
+        PasswordEncoder passwordEncoder = ApplicationContextProvider.bean(PasswordEncoder.class);
+        this.email = data.getEmail();
+        this.password = passwordEncoder.encode(data.getTemporaryPassword());
+        this.firstName = data.getFirstName();
+        this.lastName = data.getLastName();
+        this.role = Role.ADMIN;
+    }
+
 
     /**
      * Constructor to create a User from an OAuth2User (e.g., social login).

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/UserService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/UserService.java
@@ -1,9 +1,6 @@
 package com.quolance.quolance_api.services;
 
-import com.quolance.quolance_api.dtos.CreateUserRequestDto;
-import com.quolance.quolance_api.dtos.UpdateUserPasswordRequestDto;
-import com.quolance.quolance_api.dtos.UpdateUserRequestDto;
-import com.quolance.quolance_api.dtos.UserResponseDto;
+import com.quolance.quolance_api.dtos.*;
 import com.quolance.quolance_api.entities.User;
 import jakarta.validation.Valid;
 
@@ -24,4 +21,6 @@ public interface UserService {
     UserResponseDto updateUser(UpdateUserRequestDto request, User user);
 
     UserResponseDto updatePassword(UpdateUserPasswordRequestDto request, User user);
+
+    UserResponseDto createAdmin(@Valid CreateAdminRequestDto request);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/UserServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/UserServiceImpl.java
@@ -1,9 +1,6 @@
 package com.quolance.quolance_api.services.impl;
 
-import com.quolance.quolance_api.dtos.CreateUserRequestDto;
-import com.quolance.quolance_api.dtos.UpdateUserPasswordRequestDto;
-import com.quolance.quolance_api.dtos.UpdateUserRequestDto;
-import com.quolance.quolance_api.dtos.UserResponseDto;
+import com.quolance.quolance_api.dtos.*;
 import com.quolance.quolance_api.entities.PasswordResetToken;
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.entities.VerificationCode;
@@ -42,6 +39,17 @@ public class UserServiceImpl implements UserService {
         User user = new User(request);
         user = userRepository.save(user);
         sendVerificationEmail(user);
+        return new UserResponseDto(user);
+    }
+
+    @Override
+    @Transactional
+    public UserResponseDto createAdmin(CreateAdminRequestDto request) {
+        if(userRepository.existsByEmail(request.getEmail())) {
+            throw new ApiException("A user with this email already exists.");
+        }
+        User user = new User(request);
+        user = userRepository.save(user);
         return new UserResponseDto(user);
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/util/SecurityUtil.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/util/SecurityUtil.java
@@ -2,21 +2,11 @@ package com.quolance.quolance_api.util;
 
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.util.exceptions.ApiException;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.security.web.context.SecurityContextRepository;
 
 @Slf4j
 public class SecurityUtil {
-    private static final SecurityContextRepository securityContextRepository =
-            new HttpSessionSecurityContextRepository();
-
-    /**
-     * Get the authenticated user from the SecurityContextHolder
-     * @throws ApiException if the user is not found in the SecurityContextHolder
-     */
     public static User getAuthenticatedUser() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         if (principal instanceof User user) {
@@ -24,15 +14,6 @@ public class SecurityUtil {
         }else {
             log.error("User requested but not found in SecurityContextHolder");
             throw ApiException.builder().status(401).message("Authentication required").build();
-        }
-    }
-
-    public static Optional<User> getOptionalAuthenticatedUser() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if (principal instanceof User user) {
-            return Optional.of(user);
-        } else {
-            return Optional.empty();
         }
     }
 }


### PR DESCRIPTION
Admin can create admin. To make it work locally, comment out the line:
`.requestMatchers(antMatcher(HttpMethod.POST, "/api/users/admin")).hasRole("ADMIN")` in the `SecurityConfiguration` file., create an admin, then put back the restriction. Make sure you run it on `ddl-auto=update` to not delete the admin

Closes #29 