### PR TITLE
33 Admin can approve/reject a pending project

### DIFF
--- a/QuolanceAPI.postman_collection.json
+++ b/QuolanceAPI.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "7f576fc9-bd39-4ed6-a61b-0b8f862e82d0",
+		"_postman_id": "443b275e-112b-4608-a4a2-ffe820a48380",
 		"name": "QuolanceAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "39151315",
-		"_collection_link": "https://red-spaceship-708711.postman.co/workspace/Team-Workspace~e1b42c6e-212e-468e-8029-f64205a3557e/collection/19023668-7f576fc9-bd39-4ed6-a61b-0b8f862e82d0?action=share&source=collection_link&creator=39151315"
+		"_collection_link": "https://red-spaceship-708711.postman.co/workspace/Team-Workspace~e1b42c6e-212e-468e-8029-f64205a3557e/collection/39151315-443b275e-112b-4608-a4a2-ffe820a48380?action=share&source=collection_link&creator=39151315"
 	},
 	"item": [
 		{
@@ -491,6 +491,86 @@
 								"freelancer",
 								"projects",
 								"2"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "AdminController",
+			"item": [
+				{
+					"name": "Approve a project",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8081/api/admin/pending-projects/303/approve",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"api",
+								"admin",
+								"pending-projects",
+								"303",
+								"approve"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get pending projects",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8081/api/admin/pending-projects",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"api",
+								"admin",
+								"pending-projects"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reject project",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"projectId\": 102,\n  \"message\": \"Rejected message\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/api/admin/pending-projects/reject",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"api",
+								"admin",
+								"pending-projects",
+								"reject"
 							]
 						}
 					},

--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
@@ -79,6 +79,7 @@ public class SecurityConfiguration {
                     .requestMatchers(antMatcher(HttpMethod.GET, "/api/auth/impersonate/exit")).hasRole("PREVIOUS_ADMINISTRATOR")
                     .requestMatchers(antMatcher("/api/client/**")).hasRole("CLIENT")
                     .requestMatchers(antMatcher("/api/freelancer/**")).hasRole("FREELANCER")
+                    .requestMatchers(antMatcher("/api/admin/**")).hasRole("ADMIN")
                     .anyRequest().authenticated();
         });
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
@@ -1,0 +1,27 @@
+package com.quolance.quolance_api.controllers;
+
+import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.services.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminController {
+    private final AdminService adminService;
+    @Operation(
+            summary = "Approve a pending project"
+    )
+    @PostMapping("/pending-projects/{projectId}/approve")
+    public ResponseEntity<ProjectDto> approveProject(@PathVariable(name = "projectId") Long projectId) {
+
+        return ResponseEntity.ok(adminService.approveProject(projectId));
+    }
+
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
@@ -1,14 +1,12 @@
 package com.quolance.quolance_api.controllers;
 
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.dtos.RejectProjectRequestDto;
 import com.quolance.quolance_api.services.AdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +20,15 @@ public class AdminController {
     public ResponseEntity<ProjectDto> approveProject(@PathVariable(name = "projectId") Long projectId) {
 
         return ResponseEntity.ok(adminService.approveProject(projectId));
+    }
+
+    @Operation(
+            summary = "Approve a pending project"
+    )
+    @PostMapping("/pending-projects/reject")
+    public ResponseEntity<ProjectDto> rejectProject(@RequestBody RejectProjectRequestDto rejectProjectRequestDto) {
+
+        return ResponseEntity.ok(adminService.rejectProject(rejectProjectRequestDto));
     }
 
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin")
+@RequestMapping("/api/admin")
 public class AdminController {
     private final AdminService adminService;
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/AdminController.java
@@ -8,11 +8,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 public class AdminController {
     private final AdminService adminService;
+
     @Operation(
             summary = "Approve a pending project"
     )
@@ -23,12 +26,20 @@ public class AdminController {
     }
 
     @Operation(
-            summary = "Approve a pending project"
+            summary = "Reject a pending project"
     )
     @PostMapping("/pending-projects/reject")
     public ResponseEntity<ProjectDto> rejectProject(@RequestBody RejectProjectRequestDto rejectProjectRequestDto) {
 
         return ResponseEntity.ok(adminService.rejectProject(rejectProjectRequestDto));
+    }
+
+    @Operation(
+            summary = "Get all pending projects"
+    )
+    @GetMapping("/pending-projects")
+    public ResponseEntity<List<ProjectDto>> getAllPendingProjects() {
+        return ResponseEntity.ok(adminService.getAllPendingProjects());
     }
 
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/ProjectDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/ProjectDto.java
@@ -2,6 +2,7 @@ package com.quolance.quolance_api.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.quolance.quolance_api.entities.Project;
+import com.quolance.quolance_api.entities.enums.ProjectStatus;
 import com.quolance.quolance_api.entities.enums.Tag;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -19,6 +20,8 @@ public class ProjectDto {
     @JsonProperty("projectDescription")
     @NotBlank(message = "The description is required")
     private String description;
+    @JsonProperty("projectStatus")
+    private ProjectStatus projectStatus;
     @JsonProperty("clientId")
     private Long clientId;
     private List<Tag> tags;
@@ -33,6 +36,7 @@ public class ProjectDto {
     public static ProjectDto fromEntity(Project project) {
         return ProjectDto.builder()
                 .id(project.getId())
+                .projectStatus(project.getProjectStatus())
                 .description(project.getDescription())
                 .clientId(project.getClient().getId())
                 .tags(project.getTags())

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/RejectProjectRequestDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/RejectProjectRequestDto.java
@@ -1,0 +1,12 @@
+package com.quolance.quolance_api.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class RejectProjectRequestDto {
+    @JsonProperty("projectId")
+    private Long projectId;
+    @JsonProperty("message")
+    private String message;
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/Project.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/Project.java
@@ -1,11 +1,9 @@
 package com.quolance.quolance_api.entities;
 
+import com.quolance.quolance_api.entities.enums.ProjectStatus;
 import com.quolance.quolance_api.entities.enums.Tag;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
@@ -20,6 +18,10 @@ import java.util.List;
 public class Project extends AbstractEntity {
 
     private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private ProjectStatus projectStatus = ProjectStatus.PENDING;
 
     @ManyToOne
     private User client;

--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/enums/ProjectStatus.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/enums/ProjectStatus.java
@@ -1,0 +1,8 @@
+package com.quolance.quolance_api.entities.enums;
+
+public enum ProjectStatus {
+    PENDING,
+    REJECTED_AUTOMATICALLY,
+    APPROVED,
+    REJECTED
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/repositories/ProjectRepository.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/repositories/ProjectRepository.java
@@ -1,7 +1,7 @@
 package com.quolance.quolance_api.repositories;
 
 import com.quolance.quolance_api.entities.Project;
-import com.quolance.quolance_api.entities.User;
+import com.quolance.quolance_api.entities.enums.ProjectStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +15,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findAllByClientId(Long clientId);
 
     Optional<Project> findById(Long id);
+
+    List<Project> findByProjectStatus(ProjectStatus projectStatus);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/AdminService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/AdminService.java
@@ -1,7 +1,10 @@
 package com.quolance.quolance_api.services;
 
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.dtos.RejectProjectRequestDto;
 
 public interface AdminService {
     ProjectDto approveProject(Long projectId);
+
+    ProjectDto rejectProject(RejectProjectRequestDto rejectProjectRequestDto);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/AdminService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/AdminService.java
@@ -3,8 +3,12 @@ package com.quolance.quolance_api.services;
 import com.quolance.quolance_api.dtos.ProjectDto;
 import com.quolance.quolance_api.dtos.RejectProjectRequestDto;
 
+import java.util.List;
+
 public interface AdminService {
     ProjectDto approveProject(Long projectId);
 
     ProjectDto rejectProject(RejectProjectRequestDto rejectProjectRequestDto);
+
+    List<ProjectDto> getAllPendingProjects();
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/AdminService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/AdminService.java
@@ -1,0 +1,7 @@
+package com.quolance.quolance_api.services;
+
+import com.quolance.quolance_api.dtos.ProjectDto;
+
+public interface AdminService {
+    ProjectDto approveProject(Long projectId);
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
@@ -16,4 +16,6 @@ public interface ProjectService {
     Optional<Project> getProjectEntityById(Long id);
 
     List<ApplicationDto> getApplicationsToProject(Long projectId);
+
+    ProjectDto approveProject(Long projectId);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
@@ -3,6 +3,7 @@ package com.quolance.quolance_api.services;
 
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.dtos.RejectProjectRequestDto;
 import com.quolance.quolance_api.entities.Project;
 
 import java.util.List;
@@ -18,4 +19,6 @@ public interface ProjectService {
     List<ApplicationDto> getApplicationsToProject(Long projectId);
 
     ProjectDto approveProject(Long projectId);
+
+    ProjectDto rejectProject(RejectProjectRequestDto rejectProjectRequestDto);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/ProjectService.java
@@ -11,9 +11,13 @@ import java.util.Optional;
 
 public interface ProjectService {
     ProjectDto createProject(Project project);
+
     List<ProjectDto> getProjectsByClientId(Long clientId);
+
     List<ProjectDto> getAllProjects();
+
     ProjectDto getProjectById(Long id);
+
     Optional<Project> getProjectEntityById(Long id);
 
     List<ApplicationDto> getApplicationsToProject(Long projectId);
@@ -21,4 +25,6 @@ public interface ProjectService {
     ProjectDto approveProject(Long projectId);
 
     ProjectDto rejectProject(RejectProjectRequestDto rejectProjectRequestDto);
+
+    List<ProjectDto> getAllPendingProjects();
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/AdminServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/AdminServiceImpl.java
@@ -1,0 +1,17 @@
+package com.quolance.quolance_api.services.impl;
+
+import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.services.AdminService;
+import com.quolance.quolance_api.services.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+    private final ProjectService projectService;
+    @Override
+    public ProjectDto approveProject(Long projectId) {
+        return projectService.approveProject(projectId);
+    }
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/AdminServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/AdminServiceImpl.java
@@ -7,10 +7,13 @@ import com.quolance.quolance_api.services.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AdminServiceImpl implements AdminService {
     private final ProjectService projectService;
+
     @Override
     public ProjectDto approveProject(Long projectId) {
         return projectService.approveProject(projectId);
@@ -19,5 +22,10 @@ public class AdminServiceImpl implements AdminService {
     @Override
     public ProjectDto rejectProject(RejectProjectRequestDto rejectProjectRequestDto) {
         return projectService.rejectProject(rejectProjectRequestDto);
+    }
+
+    @Override
+    public List<ProjectDto> getAllPendingProjects() {
+        return projectService.getAllPendingProjects();
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/AdminServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/AdminServiceImpl.java
@@ -1,6 +1,7 @@
 package com.quolance.quolance_api.services.impl;
 
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.dtos.RejectProjectRequestDto;
 import com.quolance.quolance_api.services.AdminService;
 import com.quolance.quolance_api.services.ProjectService;
 import lombok.RequiredArgsConstructor;
@@ -13,5 +14,10 @@ public class AdminServiceImpl implements AdminService {
     @Override
     public ProjectDto approveProject(Long projectId) {
         return projectService.approveProject(projectId);
+    }
+
+    @Override
+    public ProjectDto rejectProject(RejectProjectRequestDto rejectProjectRequestDto) {
+        return projectService.rejectProject(rejectProjectRequestDto);
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
@@ -2,6 +2,7 @@ package com.quolance.quolance_api.services.impl;
 
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
+import com.quolance.quolance_api.dtos.RejectProjectRequestDto;
 import com.quolance.quolance_api.entities.Project;
 import com.quolance.quolance_api.entities.enums.ProjectStatus;
 import com.quolance.quolance_api.repositories.ProjectRepository;
@@ -72,4 +73,22 @@ public class ProjectServiceImpl implements ProjectService {
         }
         return ProjectDto.fromEntity(projectToApprove);
     }
+
+    @Override
+    public ProjectDto rejectProject(RejectProjectRequestDto rejectProjectRequestDto) {
+        Optional<Project> project = getProjectEntityById(rejectProjectRequestDto.getProjectId());
+        if (project.isEmpty()) {
+            throw new ApiException("Project not found with id: " + rejectProjectRequestDto.getProjectId());
+        }
+        Project projectToReject = project.get();
+
+        if(projectToReject.getProjectStatus() == ProjectStatus.PENDING) {
+            projectToReject.setProjectStatus(ProjectStatus.REJECTED);
+            projectToReject = projectRepository.save(projectToReject);
+        } else {
+            throw new ApiException("Project cannot be rejected at this stage.");
+        }
+        return ProjectDto.fromEntity(projectToReject);
+    }
+
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
@@ -3,9 +3,11 @@ package com.quolance.quolance_api.services.impl;
 import com.quolance.quolance_api.dtos.ApplicationDto;
 import com.quolance.quolance_api.dtos.ProjectDto;
 import com.quolance.quolance_api.entities.Project;
+import com.quolance.quolance_api.entities.enums.ProjectStatus;
 import com.quolance.quolance_api.repositories.ProjectRepository;
 import com.quolance.quolance_api.services.ApplicationService;
 import com.quolance.quolance_api.services.ProjectService;
+import com.quolance.quolance_api.util.exceptions.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -52,5 +54,22 @@ public class ProjectServiceImpl implements ProjectService {
     @Override
     public List<ApplicationDto> getApplicationsToProject(Long projectId) {
         return applicationService.getApplicationsByProjectId(projectId);
+    }
+
+    @Override
+    public ProjectDto approveProject(Long projectId) {
+        Optional<Project> project = getProjectEntityById(projectId);
+        if (project.isEmpty()) {
+            throw new ApiException("Project not found with id: " + projectId);
+        }
+        Project projectToApprove = project.get();
+
+        if(projectToApprove.getProjectStatus() == ProjectStatus.PENDING) {
+            projectToApprove.setProjectStatus(ProjectStatus.APPROVED);
+            projectToApprove = projectRepository.save(projectToApprove);
+        } else {
+            throw new ApiException("Project cannot be approved at this stage.");
+        }
+        return ProjectDto.fromEntity(projectToApprove);
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/impl/ProjectServiceImpl.java
@@ -65,7 +65,7 @@ public class ProjectServiceImpl implements ProjectService {
         }
         Project projectToApprove = project.get();
 
-        if(projectToApprove.getProjectStatus() == ProjectStatus.PENDING) {
+        if (projectToApprove.getProjectStatus() == ProjectStatus.PENDING) {
             projectToApprove.setProjectStatus(ProjectStatus.APPROVED);
             projectToApprove = projectRepository.save(projectToApprove);
         } else {
@@ -82,13 +82,21 @@ public class ProjectServiceImpl implements ProjectService {
         }
         Project projectToReject = project.get();
 
-        if(projectToReject.getProjectStatus() == ProjectStatus.PENDING) {
+        if (projectToReject.getProjectStatus() == ProjectStatus.PENDING) {
             projectToReject.setProjectStatus(ProjectStatus.REJECTED);
             projectToReject = projectRepository.save(projectToReject);
         } else {
             throw new ApiException("Project cannot be rejected at this stage.");
         }
         return ProjectDto.fromEntity(projectToReject);
+    }
+
+    @Override
+    public List<ProjectDto> getAllPendingProjects() {
+        return projectRepository.findByProjectStatus(ProjectStatus.PENDING)
+                .stream()
+                .map(ProjectDto::fromEntity)
+                .toList();
     }
 
 }


### PR DESCRIPTION
Added an enum for the project status, and it is set to PENDING upon creation.

Added 3 endpoints for an admin user:
1. Reject a project.
2. Approve a project
3. Get all pending projects

for points 1 and 2 they work only when the status of a project is PENDING, but will need to be changed later to accommodate for rejecting an existing project, or approving a project rejected by the AI model.

Closes #33