### PR TITLE
56 fe make UI for admin creates admin

### DIFF
--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/adminDashboard/adminCreateAdmin/page.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/adminDashboard/adminCreateAdmin/page.tsx
@@ -1,10 +1,14 @@
+import  {CreateAdminForm}  from "../../componentsAdmin/CreateAdminForm"
+
 
 export default function adminCreateAdmin(){
+
 
     return(
         
         <>
         <h1 className = "text-center  heading-1 m-10">Create Admin</h1>
+        <CreateAdminForm/>
         </>
     )
 }

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/adminDashboard/adminCreateAdmin/page.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/adminDashboard/adminCreateAdmin/page.tsx
@@ -1,0 +1,10 @@
+
+export default function adminCreateAdmin(){
+
+    return(
+        
+        <>
+        <h1 className = "text-center  heading-1 m-10">Create Admin</h1>
+        </>
+    )
+}

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/adminDashboard/page.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/adminDashboard/page.tsx
@@ -7,6 +7,7 @@ export default function adminDashboard (){
         <>
             <h1 className = "text-center  heading-1 m-10">Admin Dashboard</h1>
             <div className="flex flex-wrap justify-center items-center gap-8 font-bold text-xl">
+                <Link href="adminDashboard/adminCreateAdmin"> <div className = " rounded-lg border-4 w-72 h-72 flex justify-center items-center hover:bg-blue-300">Create Admin</div> </Link>
                 <Link href="adminDashboard/adminApproveProject"> <div className = " rounded-lg border-4 border-2 w-72 h-72 flex justify-center items-center hover:bg-blue-300">Approve/Reject Project</div> </Link>
             </div>
         </>

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/componentsAdmin/CreateAdminForm.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/componentsAdmin/CreateAdminForm.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import React from 'react';
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import httpClient from "@/lib/httpClient";
+import ErrorFeedback from '@/components/error-feedback';
+import { HttpErrorResponse } from '@/constants/models/http/HttpErrorResponse';
+import {useRouter } from 'next/navigation';
 
 import { PiEnvelopeSimple, PiLock, PiUser } from "react-icons/pi";
 
@@ -28,18 +32,26 @@ export function CreateAdminForm() {
     resolver: zodResolver(createAdminSchema),
   });
   const [isLoading, setIsLoading] = useState(false);
+  const [errors, setErrors] = React.useState<HttpErrorResponse | undefined>(
+    undefined
+  );
+  const router = useRouter();
 
   const onSubmit = async (data: CreateAdminSchema) => {
+    setErrors(undefined);
     setIsLoading(true);
-    try {
-      await httpClient.post("/api/users/admin", data);
-      alert("Admin created successfully!");
-    } catch (error) {
-      console.error("Error creating admin:", error);
-      alert("Failed to create admin.");
-    } finally {
+    httpClient
+    .post('/api/users/admin', data)
+    .then(() => {
+        router.push(`/adminDashboard/adminToastPage?message=Creating+Admin...&successMessage=Admin+Successfully+Created`);
+    })
+    .catch((error) => {
+      const errData = error.response.data as HttpErrorResponse;
+      setErrors(errData);
+    })
+    .finally(() => {
       setIsLoading(false);
-    }
+    });
   };
 
   return (
@@ -130,12 +142,14 @@ export function CreateAdminForm() {
             </div>
           </div>
 
+          <ErrorFeedback data={errors} />
+
           <button
             type="submit"
             className="mt-6 w-full rounded-2xl bg-blue-500 py-3 text-white font-semibold hover:bg-blue-600"
             disabled={isLoading}
           >
-            {isLoading ? "Creating Admin..." : "Create Admin"}
+            Create Admin
           </button>
         </div>
       </form>

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/componentsAdmin/CreateAdminForm.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/componentsAdmin/CreateAdminForm.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import httpClient from "@/lib/httpClient";
+
+import { PiEnvelopeSimple, PiLock, PiUser } from "react-icons/pi";
+
+const createAdminSchema = z.object({
+  email: z.string().email(),
+  temporaryPassword: z
+    .string()
+    .min(8),
+  passwordConfirmation: z.string().min(8),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+}).refine((data) => data.temporaryPassword === data.passwordConfirmation, {
+  message: "Passwords do not match",
+  path: ["passwordConfirmation"],
+});
+
+type CreateAdminSchema = z.infer<typeof createAdminSchema>;
+
+export function CreateAdminForm() {
+  const { register, handleSubmit, formState } = useForm<CreateAdminSchema>({
+    resolver: zodResolver(createAdminSchema),
+  });
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onSubmit = async (data: CreateAdminSchema) => {
+    setIsLoading(true);
+    try {
+      await httpClient.post("/api/users/admin", data);
+      alert("Admin created successfully!");
+    } catch (error) {
+      console.error("Error creating admin:", error);
+      alert("Failed to create admin.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex border rounded w-4/5 m-auto">
+      <form className="flex flex-col w-full p-8" onSubmit={handleSubmit(onSubmit)}>
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-gray-700">Email</label>
+            <div className="flex w-full items-center gap-3 rounded-2xl border px-4 py-3">
+              <span className="text-2xl">
+                <PiEnvelopeSimple />
+              </span>
+              <input
+                type="text"
+                placeholder="Enter Your Email"
+                className="w-full text-sm text-gray-700 outline-none"
+                {...register("email")}
+              />
+            </div>
+            {formState.errors.email && (
+              <small className="text-red-600">{formState.errors.email.message}</small>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-gray-700">Temporary Password</label>
+            <div className="flex w-full items-center gap-3 rounded-2xl border px-4 py-3">
+              <span className="text-2xl">
+                <PiLock />
+              </span>
+              <input
+                type="password"
+                placeholder="Enter Temporary Password"
+                className="w-full text-sm text-gray-700 outline-none"
+                {...register("temporaryPassword")}
+              />
+            </div>
+            {formState.errors.temporaryPassword && (
+              <small className="text-red-600">{formState.errors.temporaryPassword.message}</small>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-gray-700">Confirm Password</label>
+            <div className="flex w-full items-center gap-3 rounded-2xl border px-4 py-3">
+              <span className="text-2xl">
+                <PiLock />
+              </span>
+              <input
+                type="password"
+                placeholder="Confirm Password"
+                className="w-full text-sm text-gray-700 outline-none"
+                {...register("passwordConfirmation")}
+              />
+            </div>
+            {formState.errors.passwordConfirmation && (
+              <small className="text-red-600">{formState.errors.passwordConfirmation.message}</small>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-gray-700">First Name</label>
+            <div className="flex w-full items-center gap-3 rounded-2xl border px-4 py-3">
+              <span className="text-2xl">
+                <PiUser />
+              </span>
+              <input
+                type="text"
+                placeholder="Enter Your First Name"
+                className="w-full text-sm text-gray-700 outline-none"
+                {...register("firstName")}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-semibold text-gray-700">Last Name</label>
+            <div className="flex w-full items-center gap-3 rounded-2xl border px-4 py-3">
+              <span className="text-2xl">
+                <PiUser />
+              </span>
+              <input
+                type="text"
+                placeholder="Enter Your Last Name"
+                className="w-full text-sm text-gray-700 outline-none"
+                {...register("lastName")}
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="mt-6 w-full rounded-2xl bg-blue-500 py-3 text-white font-semibold hover:bg-blue-600"
+            disabled={isLoading}
+          >
+            {isLoading ? "Creating Admin..." : "Create Admin"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/componentsAdmin/CreateAdminForm.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/(admin-protected-pages)/componentsAdmin/CreateAdminForm.tsx
@@ -66,7 +66,7 @@ export function CreateAdminForm() {
               </span>
               <input
                 type="text"
-                placeholder="Enter Your Email"
+                placeholder="Enter Admin's Email"
                 className="w-full text-sm text-gray-700 outline-none"
                 {...register("email")}
               />
@@ -84,7 +84,7 @@ export function CreateAdminForm() {
               </span>
               <input
                 type="password"
-                placeholder="Enter Temporary Password"
+                placeholder="Enter Admin's Temporary Password"
                 className="w-full text-sm text-gray-700 outline-none"
                 {...register("temporaryPassword")}
               />
@@ -95,14 +95,14 @@ export function CreateAdminForm() {
           </div>
 
           <div className="flex flex-col gap-2">
-            <label className="text-sm font-semibold text-gray-700">Confirm Password</label>
+            <label className="text-sm font-semibold text-gray-700">Confirm Temporary Password</label>
             <div className="flex w-full items-center gap-3 rounded-2xl border px-4 py-3">
               <span className="text-2xl">
                 <PiLock />
               </span>
               <input
                 type="password"
-                placeholder="Confirm Password"
+                placeholder="Confirm Admin's Temporary Password"
                 className="w-full text-sm text-gray-700 outline-none"
                 {...register("passwordConfirmation")}
               />
@@ -120,7 +120,7 @@ export function CreateAdminForm() {
               </span>
               <input
                 type="text"
-                placeholder="Enter Your First Name"
+                placeholder="Enter Admin's First Name"
                 className="w-full text-sm text-gray-700 outline-none"
                 {...register("firstName")}
               />
@@ -135,7 +135,7 @@ export function CreateAdminForm() {
               </span>
               <input
                 type="text"
-                placeholder="Enter Your Last Name"
+                placeholder="Enter Admin's Last Name"
                 className="w-full text-sm text-gray-700 outline-none"
                 {...register("lastName")}
               />


### PR DESCRIPTION
Created the UI and connected it to the backend for admin create admin #10 #56 

The adminDashboard page now has a create admin option
![Screen Shot 2024-11-08 at 5 59 17 PM](https://github.com/user-attachments/assets/31425f03-9374-48ac-a189-b67e4e7895db)

Once you click on it you are navigated to the adminCreateAdmin page which has a form.
![Screen Shot 2024-11-08 at 7 08 39 PM](https://github.com/user-attachments/assets/930f5f1f-303c-4c69-917e-101b4b127a83)


If you enter incorrect credentials for email and password errors will appear in red on the form. If there are no errors a success  toast will appear and admin will be navigated to the dashboard page.
![Screen Shot 2024-11-08 at 6 05 37 PM](https://github.com/user-attachments/assets/0898ac36-4eda-47fb-8913-9bb257b05f4f)

