### PR TITLE
cicd: Added Sonar Cloud to the pipeline for code quality scans

### DIFF
--- a/.github/workflows/main-branch-analysis.yml
+++ b/.github/workflows/main-branch-analysis.yml
@@ -1,0 +1,45 @@
+name: Main Branch Analysis
+
+on:
+  workflow_run:
+    workflows: ["CI/CD Pipeline"]
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  analyze-main:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Frontend Analysis
+        uses: SonarSource/sonarqube-scan-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: quolance-ui
+          args: >
+            -Dsonar.organization=abdelh17
+            -Dsonar.projectKey=abdelh17_Quolance_ui
+            -Dsonar.sources=.
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.branch.name=main
+
+      - name: Backend Analysis
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          cd quolance-api
+          ./mvnw verify sonar:sonar \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.organization=abdelh17 \
+            -Dsonar.projectKey=abdelh17_Quolance_api \
+            -Dsonar.branch.name=main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # Step 1: Install Dependencies
       - name: Install Dependencies
@@ -26,11 +28,26 @@ jobs:
       #     cd quolance-ui
       #     npm test
 
-      # Step 3: Build Frontend Package
+      # Step 3: Build Frontend
       - name: Build Frontend
         run: |
           cd quolance-ui
           npm run build
+
+      # Step 4: SonarCloud Scan for Frontend
+      - name: SonarCloud Scan Frontend
+        uses: SonarSource/sonarqube-scan-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: quolance-ui
+          args: >
+            -Dsonar.organization=abdelh17
+            -Dsonar.projectKey=abdelh17_Quolance_ui
+            -Dsonar.sources=.
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.host.url=https://sonarcloud.io
 
   backend-build-test:
     name: Build and Test Backend
@@ -41,6 +58,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       # Set up JDK for Spring Boot
       - name: Set up JDK 21
@@ -55,3 +74,15 @@ jobs:
           cd quolance-api
           ./mvnw clean install
           ./mvnw test
+
+      # SonarCloud Scan for Backend
+      - name: SonarCloud Scan Backend
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          cd quolance-api
+          ./mvnw verify sonar:sonar \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.organization=abdelh17 \
+            -Dsonar.projectKey=abdelh17_Quolance_api

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   frontend-build-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,21 +68,14 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      # Build and test Spring Boot backend
-      - name: Build and Test Spring Boot
-        run: |
-          cd quolance-api
-          ./mvnw clean install
-          ./mvnw test
-
-      # SonarCloud Scan for Backend
-      - name: SonarCloud Scan Backend
+      - name: Build, Test, and Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           cd quolance-api
-          ./mvnw verify sonar:sonar \
+          ./mvnw clean verify sonar:sonar \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.organization=abdelh17 \
-            -Dsonar.projectKey=abdelh17_Quolance_api
+            -Dsonar.projectKey=abdelh17_Quolance_api \
+            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml

--- a/quolance-api/pom.xml
+++ b/quolance-api/pom.xml
@@ -146,6 +146,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
 				<executions>
 					<execution>
 						<goals>

--- a/quolance-ui/sonar-project.properties
+++ b/quolance-ui/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.sources=.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.exclusions=**/node_modules/**,**/*.test.js,**/*.spec.js


### PR DESCRIPTION
# In this PR:
- Added SonarCloud scan in the pipeline whenever a PR is made. 
- Automates the scans that were previously manually ran locally.
- Will allow us to fix code defects and improve the quality of the code
- Added the version of the jacoco maven plugin because to address warning messages in previous builds.

## Where to access results
- 2 scans are executed: 1 for frontend, 1 for backend.
- In SonarCloud, they are setup as 2 projects within a monorepo.

- Backend: [Backend scan](https://sonarcloud.io/summary/new_code?id=abdelh17_Quolance_api)
- Frontend: [Frontend scan](https://sonarcloud.io/project/overview?id=abdelh17_Quolance_ui)

# What this adds:
## General information about the state of the project
![image](https://github.com/user-attachments/assets/81bac79c-314b-4beb-9e49-e896d01ce492)

## Code smells
![image](https://github.com/user-attachments/assets/221b2fea-a9a6-4a3e-b2f5-f2f29d022711)

## Code coverage:
![image](https://github.com/user-attachments/assets/799e73d6-5893-437d-9017-26ea165886e1)
![image](https://github.com/user-attachments/assets/09bb67a5-8603-450d-a97e-73e5faef74e1)

## Next steps
Fix bug smells and add tests!

Closes #180