### PR TITLE
bugfix: Validate empty strings in project update

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project presents a cutting-edge freelancing platform that connects freelanc
 | Francesco Ferrato          | 26642152   | franf91          | francescoferrato937@gmail.com  |
 | Ismail Feham               | 40213442   | FehamIsmail      | ismail.feham64@gmail.com       |
 | Abdelmalek Anes            | 40229242   | NotMalek         | malekanes213@gmail.com         |
-| Oussama Cherifi            | 40212275   | OussamaCherifi   | oussama.cherifi7@gmail.com     |
+| Oussama Cherifi            | 40212275   | OussamaCherifi   | oussamacherifi7@gmail.com     |
 | Sathurthikan Saththyvel    | 40213455   | SSathu           | sathuow@gmail.com              |
 | Zakaria El Manar El Bouanani| 40190432   | Zakaria0907      | zakaria.elmanar@gmail.com      |
 | Fadi Nimer| 40183225   | Lukateki      | fadi_nimer@hotmail.com      |

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
@@ -113,10 +113,18 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public void updateProject(Project existingProject, ProjectUpdateDto updateDto) {
-        // First validate the update DTO
+        // First validate update DTO
         validateUpdateDto(updateDto);
 
-        // Then proceed with the update
+        // Validate project status
+        if (existingProject.getProjectStatus() != ProjectStatus.PENDING) {
+            throw ApiException.builder()
+                    .status(HttpServletResponse.SC_FORBIDDEN)
+                    .message("Project can only be updated when in PENDING state")
+                    .build();
+        }
+
+        // Proceed with update
         updateProjectFields(existingProject, updateDto);
         projectRepository.save(existingProject);
     }
@@ -181,6 +189,10 @@ public class ProjectServiceImpl implements ProjectService {
 
         if (updateDto.getExpectedDeliveryTime() != null) {
             project.setExpectedDeliveryTime(updateDto.getExpectedDeliveryTime());
+        }
+
+        if (updateDto.getExperienceLevel() != null) {
+            project.setExperienceLevel(updateDto.getExperienceLevel());
         }
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
@@ -113,6 +113,15 @@ public class ProjectServiceImpl implements ProjectService {
 
     @Override
     public void updateProject(Project existingProject, ProjectUpdateDto updateDto) {
+        // First validate the update DTO
+        validateUpdateDto(updateDto);
+
+        // Then proceed with the update
+        updateProjectFields(existingProject, updateDto);
+        projectRepository.save(existingProject);
+    }
+
+    private void validateUpdateDto(ProjectUpdateDto updateDto) {
         if (updateDto == null) {
             throw ApiException.builder()
                     .status(HttpServletResponse.SC_BAD_REQUEST)
@@ -120,24 +129,46 @@ public class ProjectServiceImpl implements ProjectService {
                     .build();
         }
 
-        if (existingProject.getProjectStatus() != ProjectStatus.PENDING) {
+        // Validate title
+        if (updateDto.getTitle() != null && updateDto.getTitle().trim().isEmpty()) {
             throw ApiException.builder()
-                    .status(HttpServletResponse.SC_FORBIDDEN)
-                    .message("Project can only be updated when in PENDING state")
+                    .status(HttpServletResponse.SC_BAD_REQUEST)
+                    .message("Title cannot be empty")
                     .build();
         }
 
-        updateProjectFields(existingProject, updateDto);
-        projectRepository.save(existingProject);
+        // Validate description
+        if (updateDto.getDescription() != null && updateDto.getDescription().trim().isEmpty()) {
+            throw ApiException.builder()
+                    .status(HttpServletResponse.SC_BAD_REQUEST)
+                    .message("Description cannot be empty")
+                    .build();
+        }
+
+        // Validate category
+        if (updateDto.getCategory() != null && updateDto.getCategory().toString().trim().isEmpty()) {
+            throw ApiException.builder()
+                    .status(HttpServletResponse.SC_BAD_REQUEST)
+                    .message("Category cannot be empty")
+                    .build();
+        }
+
+        // Validate priceRange
+        if (updateDto.getPriceRange() != null && updateDto.getPriceRange().toString().trim().isEmpty()) {
+            throw ApiException.builder()
+                    .status(HttpServletResponse.SC_BAD_REQUEST)
+                    .message("Price range cannot be empty")
+                    .build();
+        }
     }
 
     private void updateProjectFields(Project project, ProjectUpdateDto updateDto) {
         if (updateDto.getTitle() != null) {
-            project.setTitle(updateDto.getTitle());
+            project.setTitle(updateDto.getTitle().trim());
         }
 
         if (updateDto.getDescription() != null) {
-            project.setDescription(updateDto.getDescription());
+            project.setDescription(updateDto.getDescription().trim());
         }
 
         if (updateDto.getCategory() != null) {
@@ -150,10 +181,6 @@ public class ProjectServiceImpl implements ProjectService {
 
         if (updateDto.getExpectedDeliveryTime() != null) {
             project.setExpectedDeliveryTime(updateDto.getExpectedDeliveryTime());
-        }
-
-        if (updateDto.getExperienceLevel() != null) {
-            project.setExperienceLevel(updateDto.getExperienceLevel());
         }
     }
 }


### PR DESCRIPTION
Prevents updating with empty fields (title/desc/category/price). Returns 400 Bad Request. 
Closes #178