### PR TITLE
feat: Make UI for settings page for #122

### DIFF
--- a/quolance-ui/package-lock.json
+++ b/quolance-ui/package-lock.json
@@ -48,7 +48,8 @@
         "swr": "^2.2.5",
         "tailwind-merge": "^1.13.2",
         "uuid": "^9.0.1",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
         "@svgr/webpack": "^6.5.1",
@@ -16991,6 +16992,11 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ=="
     }
   }
 }

--- a/quolance-ui/package.json
+++ b/quolance-ui/package.json
@@ -57,7 +57,8 @@
     "swr": "^2.2.5",
     "tailwind-merge": "^1.13.2",
     "uuid": "^9.0.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@svgr/webpack": "^6.5.1",

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/ChangePassword.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/ChangePassword.tsx
@@ -76,6 +76,15 @@ export default function ChangePassword() {
              }
        }
 
+       if (error.response?.status === 422){
+        if (errData?.message === "Unprocessable entity") {
+            setError("password", {
+              type: "manual",
+              message: "New password must contain one uppercase letter, one lowercase letter, and one digit.",
+            });
+          }
+    }
+
 
      })
      .finally(() => {

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/ChangePassword.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/ChangePassword.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+
+import httpClient from "@/lib/httpClient";
+
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { HttpErrorResponse } from "@/constants/models/http/HttpErrorResponse";
+import { showToast } from "@/util/context/ToastProvider";
+
+
+import PasswordStrengthBar from "./PasswordStrengthBar";
+
+
+
+
+const changePasswordSchema = z
+ .object({
+   oldPassword: z.string().min(1, "Current password is required"),
+   password: z.string().min(8, "New password must be at least 8 characters long"),
+   confirmPassword: z.string().min(1, "Password confirmation is required"),
+ })
+ .refine((data) => data.password === data.confirmPassword, {
+   message: "Passwords do not match",
+   path: ["confirmPassword"],
+ });
+
+
+type Schema = z.infer<typeof changePasswordSchema>;
+
+
+export default function ChangePassword() {
+ const [isLoading, setIsLoading] = useState(false);
+
+
+ const { register, handleSubmit, formState, reset,setError,clearErrors} = useForm<Schema>({
+   resolver: zodResolver(changePasswordSchema),
+   reValidateMode: "onSubmit",
+ });
+
+
+ const [password, setPassword] = useState("");
+
+
+ async function onSubmit(data: Schema) {
+  
+  
+   setIsLoading(true);
+
+
+   httpClient
+     .patch("/api/users/password", data)
+     .then(() => {
+       showToast("The password has been changed successfully", "success");
+       reset();
+       setPassword("");
+     })
+     .catch((error) => {
+       const errData = error.response?.data as HttpErrorResponse;
+
+
+       if (error.response?.status === 400){
+           if (errData?.message === "Wrong password") {
+               setError("oldPassword", {
+                 type: "manual",
+                 message: "The current password is incorrect.",
+               });
+             }
+       }
+
+
+     })
+     .finally(() => {
+       setIsLoading(false);
+     });
+ }
+
+
+ return (
+   <div className="grid grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+     <div>
+       <h2 className="text-base/7 font-semibold">Change password</h2>
+       <p className="mt-1 text-sm/6 text-gray-400">
+         Update your password associated with your account.
+       </p>
+     </div>
+
+
+     <form
+       onSubmit={handleSubmit(onSubmit)}
+       className="md:col-span-2 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6"
+     >
+      
+       <div className="col-span-full">
+         <Label htmlFor="oldPassword">Current password</Label>
+         <Input
+           id="oldPassword"
+           type="password"
+           autoComplete="current-password"
+           disabled={isLoading}
+           {...register("oldPassword")}
+           className="block w-full rounded-md px-3 py-1.5 outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
+           onChange={() => clearErrors("oldPassword")}
+         />
+         {formState.errors.oldPassword && (
+           <small className="text-red-600">{formState.errors.oldPassword.message}</small>
+         )}
+       </div>
+
+
+      
+       <div className="col-span-full">
+         <Label htmlFor="password">New password</Label>
+         <Input
+           id="password"
+           type="password"
+           autoComplete="new-password"
+           disabled={isLoading}
+           {...register("password")}
+           className="block w-full rounded-md px-3 py-1.5 text-base outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
+           onChange={(e) => {
+               clearErrors("password");
+               setPassword(e.target.value);
+             }}
+         />
+        
+         {formState.errors.password && (
+           <small className="text-red-600">{formState.errors.password.message}</small>
+         )}
+         {password.length >= 1 && <PasswordStrengthBar password={password} />}
+       </div>
+
+
+       <div className="col-span-full">
+         <Label htmlFor="confirmPassword">Confirm password</Label>
+         <Input
+           id="confirmPassword"
+           type="password"
+           autoComplete="new-password"
+           disabled={isLoading}
+           {...register("confirmPassword")}
+           className="block w-full rounded-md px-3 py-1.5 text-base outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
+           onChange={() => clearErrors("confirmPassword")}
+         />
+         {formState.errors.confirmPassword && (
+           <small className="text-red-600">{formState.errors.confirmPassword.message}</small>
+         )}
+       </div>
+
+
+       <div className="mt-8 flex">
+         <Button
+           type="submit"
+           disabled={isLoading}
+           className="rounded-md bg-blue-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-900 "
+         >
+           {isLoading ? "Updating..." : "Change Password"}
+         </Button>
+       </div>
+     </form>
+   </div>
+ );
+}

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/DeleteAccount.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/DeleteAccount.tsx
@@ -1,0 +1,26 @@
+export default function DeleteAccount(){
+
+
+    return(
+        <div className="grid grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+                <div>
+                  <h2 className="text-base/7 font-semibold ">Delete account</h2>
+                  <p className="mt-1 text-sm/6 text-gray-400">
+                    No longer want to use our service? You can delete your account here. This action is not reversible.
+                    All information related to this account will be deleted permanently.
+                  </p>
+                </div>
+ 
+ 
+                <form className="flex items-start md:col-span-2">
+                  <button
+                    type="submit"
+                    className="rounded-md bg-red-500 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-900"
+                  >
+                    Yes, Delete My Account
+                  </button>
+                </form>
+              </div>
+    )
+ }
+ 

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PasswordStrengthBar.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PasswordStrengthBar.tsx
@@ -1,0 +1,31 @@
+import zxcvbn from "zxcvbn";
+
+
+interface PasswordStrengthBarProps {
+ password?: string;
+}
+
+
+export default function PasswordStrengthBar({ password = "" }: PasswordStrengthBarProps) {
+ const strength = zxcvbn(password).score;
+
+ const strengthLabels = ["Very Weak", "Weak", "Fair", "Strong", "Very Strong"];
+ const strengthColors = ["bg-red-500", "bg-orange-500", "bg-yellow-500", "bg-blue-500", "bg-green-500"];
+
+
+ return (
+   <div className = "mt-2">
+     <div className="h-2 w-full bg-gray-200 rounded">
+       <div
+         className={`h-2 rounded ${strengthColors[strength]}`}
+         style={{ width: `${(strength + 1) * 20}%` }}
+       ></div>
+     </div>
+
+
+     <div className="flex justify-end text-sm/6">
+       {strengthLabels[strength]}
+     </div>
+   </div>
+ );
+}

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PasswordStrengthBar.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PasswordStrengthBar.tsx
@@ -1,31 +1,28 @@
 import zxcvbn from "zxcvbn";
 
-
 interface PasswordStrengthBarProps {
- password?: string;
+  password: string;
 }
 
+export default function PasswordStrengthBar(props: Readonly<PasswordStrengthBarProps>) {
+  const password = props.password || ""; // Fallback to empty string if password is undefined
+  const strength = zxcvbn(password).score;
 
-export default function PasswordStrengthBar({ password = "" }: PasswordStrengthBarProps) {
- const strength = zxcvbn(password).score;
+  const strengthLabels = ["Very Weak", "Weak", "Fair", "Strong", "Very Strong"];
+  const strengthColors = ["bg-red-500", "bg-orange-500", "bg-yellow-500", "bg-blue-500", "bg-green-500"];
 
- const strengthLabels = ["Very Weak", "Weak", "Fair", "Strong", "Very Strong"];
- const strengthColors = ["bg-red-500", "bg-orange-500", "bg-yellow-500", "bg-blue-500", "bg-green-500"];
+  return (
+    <div className="mt-2">
+      {/* Strength Bar */}
+      <div className="h-2 w-full bg-gray-200 rounded">
+        <div
+          className={`h-2 rounded ${strengthColors[strength]}`}
+          style={{ width: `${(strength + 1) * 20}%` }}
+        ></div>
+      </div>
 
-
- return (
-   <div className = "mt-2">
-     <div className="h-2 w-full bg-gray-200 rounded">
-       <div
-         className={`h-2 rounded ${strengthColors[strength]}`}
-         style={{ width: `${(strength + 1) * 20}%` }}
-       ></div>
-     </div>
-
-
-     <div className="flex justify-end text-sm/6">
-       {strengthLabels[strength]}
-     </div>
-   </div>
- );
+      {/* Strength Label */}
+      <div className="flex justify-end text-sm/6">{strengthLabels[strength]}</div>
+    </div>
+  );
 }

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PersonalInfo.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PersonalInfo.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useAuthGuard } from '@/api/auth-api';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+
+export default function PersonalInfo() {
+ const { user } = useAuthGuard({ middleware: 'auth' });
+
+
+ return (
+   <div className="grid grid-cols-1 gap-x-8 gap-y-10 px-4 py-16 sm:px-6 md:grid-cols-3 lg:px-8">
+     <div>
+       <h2 className="text-base/7 font-semibold">Personal Information</h2>
+       <p className="mt-1 text-sm/6 text-gray-400">
+         View your personal information associated with your account.
+       </p>
+     </div>
+
+
+     <form className="md:col-span-2">
+       <div className="grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+         <div className="sm:col-span-3">
+           <Label htmlFor="first-name">First name</Label>
+           <Input
+             id="first-name"
+             type="text"
+             autoComplete="given-name"
+             value={user?.firstName || ''}
+             disabled
+             className="block w-full rounded-md px-3 py-1.5 outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
+           />
+         </div>
+
+
+        
+         <div className="sm:col-span-3">
+           <Label htmlFor="last-name">Last name</Label>
+           <Input
+             id="last-name"
+             type="text"
+             autoComplete="family-name"
+             value={user?.lastName || ''}
+             disabled
+             className="block w-full rounded-md px-3 py-1.5 outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
+           />
+         </div>
+
+
+        
+         <div className="col-span-full">
+           <Label htmlFor="email">Email address</Label>
+           <Input
+             id="email"
+             type="email"
+             autoComplete="email"
+             value={user?.email || ''}
+             disabled
+             className="block w-full rounded-md px-3 py-1.5 outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
+           />
+         </div>
+       </div>
+     </form>
+   </div>
+ );
+}
+''

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PersonalInfo.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PersonalInfo.tsx
@@ -27,7 +27,7 @@ export default function PersonalInfo() {
              id="first-name"
              type="text"
              autoComplete="given-name"
-             value={user?.firstName || ''}
+             value={user?.firstName ?? ''}
              disabled
              className="block w-full rounded-md px-3 py-1.5 outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
            />
@@ -41,7 +41,7 @@ export default function PersonalInfo() {
              id="last-name"
              type="text"
              autoComplete="family-name"
-             value={user?.lastName || ''}
+             value={user?.lastName ?? ''}
              disabled
              className="block w-full rounded-md px-3 py-1.5 outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
            />
@@ -55,7 +55,7 @@ export default function PersonalInfo() {
              id="email"
              type="email"
              autoComplete="email"
-             value={user?.email || ''}
+             value={user?.email ?? ''}
              disabled
              className="block w-full rounded-md px-3 py-1.5 outline outline-1 focus:outline-indigo-500 sm:text-sm/6"
            />

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PersonalInfo.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/PersonalInfo.tsx
@@ -65,4 +65,3 @@ export default function PersonalInfo() {
    </div>
  );
 }
-''

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/page.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/page.tsx
@@ -1,0 +1,34 @@
+
+import PersonalInfo from './components/PersonalInfo';
+import ChangePassword from './components/ChangePassword';
+import DeleteAccount from './components/DeleteAccount';
+
+
+export default function SettingPage() {
+
+ return (
+   <>
+       <div className="flex justify-center">
+        
+           <div className="divide-y max-w-5xl">
+          
+           <div className=" px-4 py-4  lg:px-8">
+               <h2 className="text-base/7 font-semibold ">Account Settings</h2>
+               <p className="mt-1 text-sm/6 text-gray-400">
+                      View and Manage your account settings.
+               </p>
+           </div>
+          
+             <PersonalInfo/>
+
+
+             <ChangePassword/>
+
+
+            <DeleteAccount/>
+            
+           </div>
+       </div>
+   </>
+ )
+}

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/page.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/page.tsx
@@ -7,7 +7,6 @@ import DeleteAccount from './components/DeleteAccount';
 export default function SettingPage() {
 
  return (
-   <>
        <div className="flex justify-center">
         
            <div className="divide-y max-w-5xl">
@@ -29,6 +28,5 @@ export default function SettingPage() {
             
            </div>
        </div>
-   </>
  )
 }

--- a/quolance-ui/zxcvbn.d.ts
+++ b/quolance-ui/zxcvbn.d.ts
@@ -1,0 +1,6 @@
+declare module "zxcvbn" {
+    export interface ZxcvbnResult {
+      score: number; 
+    }
+     export default function zxcvbn(password: string, userInputs?: string[]): ZxcvbnResult;
+  }


### PR DESCRIPTION
This is for  task #122 which is linked to story #121 

The setting page is currently only accessible through url at /setting for authenticated accounts.

In this page you can view personal information like first name, last name and email address. 

In this page you can change the current password by inputing current password, new password and confirmation password. The appropriate error messages will display below each input. There are error messages for the following
- Empty fields
- Current password not being correct
- New password having less than 8 characters
- Confirm password not equal to new password
- The new password is of correct length but format incorrect ( missing either capital letter, lower case letter or digit)

In this page there is a button to delete account which is not yet implemented.

![Screen Shot 2024-12-20 at 11 04 44 PM](https://github.com/user-attachments/assets/ac91d106-3090-4f81-b9c0-b229b60d2833)

The password strength bar was created using the 'zxcvbn' library. The password strength bar has the following labels

Very Weak
![Screen Shot 2024-12-20 at 11 11 17 PM](https://github.com/user-attachments/assets/89b2754c-71cd-4c45-83ef-a62e37af6d2a)

Weak
![Screen Shot 2024-12-20 at 11 12 06 PM](https://github.com/user-attachments/assets/0ce03b9f-66f8-4fcc-af99-283f633a7c94)

Fair
![Screen Shot 2024-12-20 at 11 12 20 PM](https://github.com/user-attachments/assets/51200ec7-a4a4-4c4e-8e43-d95998adb3c6)

Strong
![Screen Shot 2024-12-20 at 11 12 42 PM](https://github.com/user-attachments/assets/73f375b1-3a74-4485-8446-654dec8dc73a)

Very Strong
![Screen Shot 2024-12-20 at 11 12 57 PM](https://github.com/user-attachments/assets/ffb6cab1-508c-4a9f-a4df-7aa44278dab7)


