### PR TITLE
test: Fixed Commented Tests to work for newly implemented pagination methods

### DIFF
--- a/quolance-api/src/test/java/com/quolance/quolance_api/integration/AdminControllerIntegrationTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/integration/AdminControllerIntegrationTest.java
@@ -68,30 +68,33 @@ public class AdminControllerIntegrationTest extends AbstractTestcontainers {
                 .getSession();
     }
 
-//    @Test
-//    void getAllPendingProjectIsOk() throws Exception {
-//        // Arrange
-//        Project pendingProject = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.PENDING, client));
-//        Project openProject = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.OPEN, client));
-//
-//        // Act
-//        String response = mockMvc.perform(get("/api/admin/projects/pending/all")
-//                        .session(session))
-//                .andExpect(status().isOk())
-//                .andReturn()
-//                .getResponse()
-//                .getContentAsString();
-//
-//        List<Object> responseList = objectMapper.readValue(response, List.class);
-//
-//        // Assert
-//        assertThat(responseList.size()).isEqualTo(1);
-//
-//        Map<String, Object> projectResponse = (Map<String, Object>) responseList.get(0);
-//
-//        assertThat(projectResponse.get("id")).isEqualTo(pendingProject.getId().intValue());
-//        assertThat(projectResponse.get("projectStatus")).isEqualTo("PENDING");
-//    }
+    @Test
+    void getAllPendingProjectIsOk() throws Exception {
+        // Arrange
+        Project pendingProject = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.PENDING, client));
+        Project openProject = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.OPEN, client));
+
+        // Act
+        String response = mockMvc.perform(get("/api/admin/projects/pending/all")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortDirection", "asc")
+                        .session(session))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Map<String,Object> responseMap = objectMapper.readValue(response, Map.class);
+        List<Map<String,Object>> content = (List<Map<String, Object>>) responseMap.get("content");
+
+        // Assert
+        assertThat(content.size()).isEqualTo(1);
+
+        Map<String, Object> projectResponse = (Map<String, Object>) content.get(0);
+
+        assertThat(projectResponse.get("id")).isEqualTo(pendingProject.getId().intValue());
+        assertThat(projectResponse.get("projectStatus")).isEqualTo("PENDING");
+    }
 
     @Test
     void approvePendingProjectIsOkBecomesApproved() throws Exception {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/integration/FreelancerControllerIntegrationTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/integration/FreelancerControllerIntegrationTest.java
@@ -255,49 +255,53 @@ public class FreelancerControllerIntegrationTest extends AbstractTestcontainers 
         assertThat(applicationResponse2.get("freelancerId")).isEqualTo(freelancer.getId().intValue());
     }
 
-//    @Test
-//    void getAllProjectsReturnsVisibleProjects() throws Exception {
-//        //Arrange
-//        Project project1 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.OPEN, LocalDate.now().plusDays(7), client));
-//
-//        Project project2 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.CLOSED, LocalDate.now().plusDays(2), client));
-//
-//        Project project3 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.PENDING, LocalDate.now().plusDays(7), client));
-//
-//        Project project4 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.OPEN, LocalDate.now().plusDays(7), client));
-//
-//        Project project5 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.CLOSED, LocalDate.now().minusDays(7), client));
-//
-//
-//        //Act
-//        String response = mockMvc.perform(get("/api/freelancer/projects/all")
-//                        .session(session))
-//                .andExpect(status().isOk())
-//                .andReturn()
-//                .getResponse()
-//                .getContentAsString();
-//
-//        List<Object> responseList = objectMapper.readValue(response, List.class);
-//
-//        //Assert
-//        assertThat(responseList).hasSize(3);
-//
-//        Map<String, Object> projectResponse1 = (Map<String, Object>) responseList.get(0);
-//        Map<String, Object> projectResponse2 = (Map<String, Object>) responseList.get(1);
-//        Map<String, Object> projectResponse3 = (Map<String, Object>) responseList.get(2);
-//
-//        assertThat(projectResponse1.get("id")).isEqualTo(project1.getId().intValue());
-//        assertThat(projectResponse1.get("projectStatus")).isEqualTo("OPEN");
-//        assertThat(projectResponse1.get("projectStatus")).isEqualTo(project1.getProjectStatus().name());
-//
-//        assertThat(projectResponse2.get("id")).isEqualTo(project2.getId().intValue());
-//        assertThat(projectResponse2.get("projectStatus")).isEqualTo("CLOSED");
-//        assertThat(projectResponse2.get("projectStatus")).isEqualTo(project2.getProjectStatus().name());
-//
-//        assertThat(projectResponse3.get("id")).isEqualTo(project4.getId().intValue());
-//        assertThat(projectResponse3.get("projectStatus")).isEqualTo("OPEN");
-//        assertThat(projectResponse3.get("projectStatus")).isEqualTo(project4.getProjectStatus().name());
-//    }
+    @Test
+    void getAllProjectsReturnsVisibleProjects() throws Exception {
+        //Arrange
+        Project project1 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.OPEN, LocalDate.now().plusDays(7), client));
+
+        Project project2 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.CLOSED, LocalDate.now().plusDays(2), client));
+
+        Project project3 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.PENDING, LocalDate.now().plusDays(7), client));
+
+        Project project4 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.OPEN, LocalDate.now().plusDays(7), client));
+
+        Project project5 = projectRepository.save(EntityCreationHelper.createProject(ProjectStatus.CLOSED, LocalDate.now().minusDays(7), client));
+
+
+        //Act
+        String response = mockMvc.perform(get("/api/freelancer/projects/all")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sortDirection", "asc")
+                        .session(session))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        Map<String, Object> responseMap = objectMapper.readValue(response, Map.class);
+        List<Map<String, Object>> content = (List<Map<String, Object>>) responseMap.get("content");
+
+        //Assert
+        assertThat(content).hasSize(3);
+
+        Map<String, Object> projectResponse1 = (Map<String, Object>) content.get(0);
+        Map<String, Object> projectResponse2 = (Map<String, Object>) content.get(1);
+        Map<String, Object> projectResponse3 = (Map<String, Object>) content.get(2);
+
+        assertThat(projectResponse1.get("id")).isEqualTo(project1.getId().intValue());
+        assertThat(projectResponse1.get("projectStatus")).isEqualTo("OPEN");
+        assertThat(projectResponse1.get("projectStatus")).isEqualTo(project1.getProjectStatus().name());
+
+        assertThat(projectResponse2.get("id")).isEqualTo(project2.getId().intValue());
+        assertThat(projectResponse2.get("projectStatus")).isEqualTo("CLOSED");
+        assertThat(projectResponse2.get("projectStatus")).isEqualTo(project2.getProjectStatus().name());
+
+        assertThat(projectResponse3.get("id")).isEqualTo(project4.getId().intValue());
+        assertThat(projectResponse3.get("projectStatus")).isEqualTo("OPEN");
+        assertThat(projectResponse3.get("projectStatus")).isEqualTo(project4.getProjectStatus().name());
+    }
 
     @Test
     void getProjectByIdIsOk() throws Exception {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/PublicControllerUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/PublicControllerUnitTest.java
@@ -1,8 +1,12 @@
 package com.quolance.quolance_api.unit;
 
 import com.quolance.quolance_api.controllers.PublicController;
+import com.quolance.quolance_api.dtos.PageResponseDto;
+import com.quolance.quolance_api.dtos.PageableRequestDto;
+import com.quolance.quolance_api.dtos.project.ProjectFilterDto;
 import com.quolance.quolance_api.dtos.project.ProjectPublicDto;
 import com.quolance.quolance_api.services.business_workflow.FreelancerWorkflowService;
+import com.quolance.quolance_api.util.PaginationUtils;
 import com.quolance.quolance_api.util.exceptions.ApiException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +14,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -27,6 +35,9 @@ class PublicControllerUnitTest {
 
     @Mock
     private FreelancerWorkflowService freelancerWorkflowService;
+
+    @Mock
+    private PaginationUtils paginationUtils;
 
     @InjectMocks
     private PublicController publicController;
@@ -52,49 +63,62 @@ class PublicControllerUnitTest {
         );
     }
 
-//    @Test
-//    void getAllAvailableProjects_ShouldReturnProjects_WhenProjectsExist() {
-//        when(freelancerWorkflowService.getAllAvailableProjects()).thenReturn(sampleProjects);
-//
-//        ResponseEntity<List<ProjectPublicDto>> response = publicController.getAllAvailableProjects();
-//
-//        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-//        assertThat(response.getBody())
-//                .isNotNull()
-//                .hasSize(2)
-//                .isEqualTo(sampleProjects);
-//        verify(freelancerWorkflowService).getAllAvailableProjects();
-//        verifyNoMoreInteractions(freelancerWorkflowService);
-//    }
+    @Test
+    void getAllAvailableProjects_ShouldReturnProjects_WhenProjectsExist() {
+        PageableRequestDto pageableRequestDto = new PageableRequestDto();
+        pageableRequestDto.setPage(0);
+        pageableRequestDto.setSize(10);
+        Page<ProjectPublicDto> projectPage = new PageImpl<>(sampleProjects);
+        when(freelancerWorkflowService.getAllAvailableProjects(any(Pageable.class), any(ProjectFilterDto.class)))
+                .thenReturn(projectPage);
 
-//    @Test
-//    void getAllAvailableProjects_ShouldReturnEmptyList_WhenNoProjects() {
-//        when(freelancerWorkflowService.getAllAvailableProjects()).thenReturn(Collections.emptyList());
-//
-//        ResponseEntity<List<ProjectPublicDto>> response = publicController.getAllAvailableProjects();
-//
-//        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-//        assertThat(response.getBody())
-//                .isNotNull()
-//                .isEmpty();
-//        verify(freelancerWorkflowService).getAllAvailableProjects();
-//        verifyNoMoreInteractions(freelancerWorkflowService);
-//    }
+        ResponseEntity<PageResponseDto<ProjectPublicDto>> response = publicController.getAllAvailableProjects(pageableRequestDto, new ProjectFilterDto());
 
-//    @Test
-//    void getAllAvailableProjects_ShouldThrowApiException_WhenServiceFails() {
-//        when(freelancerWorkflowService.getAllAvailableProjects())
-//                .thenThrow(ApiException.builder()
-//                        .message("Failed to fetch projects")
-//                        .status(500)
-//                        .build());
-//
-//        assertThatThrownBy(() -> publicController.getAllAvailableProjects())
-//                .isInstanceOf(ApiException.class)
-//                .hasMessage("Failed to fetch projects");
-//        verify(freelancerWorkflowService).getAllAvailableProjects();
-//        verifyNoMoreInteractions(freelancerWorkflowService);
-//    }
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent())
+                .isNotNull()
+                .hasSize(2)
+                .isEqualTo(sampleProjects);
+        verify(freelancerWorkflowService).getAllAvailableProjects(any(Pageable.class), any(ProjectFilterDto.class));
+        verifyNoMoreInteractions(freelancerWorkflowService);
+    }
+
+    @Test
+    void getAllAvailableProjects_ShouldReturnEmptyList_WhenNoProjects() {
+        PageableRequestDto pageableRequestDto = new PageableRequestDto();
+        pageableRequestDto.setPage(0);
+        pageableRequestDto.setSize(10);
+        Page<ProjectPublicDto> emptyPage = new PageImpl<>(Collections.emptyList());
+        when(freelancerWorkflowService.getAllAvailableProjects(any(Pageable.class), any(ProjectFilterDto.class)))
+                .thenReturn(emptyPage);
+
+        ResponseEntity<PageResponseDto<ProjectPublicDto>> response = publicController.getAllAvailableProjects(pageableRequestDto, new ProjectFilterDto());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getContent())
+                .isNotNull()
+                .isEmpty();
+        verify(freelancerWorkflowService).getAllAvailableProjects(any(Pageable.class), any(ProjectFilterDto.class));
+        verifyNoMoreInteractions(freelancerWorkflowService);
+    }
+
+    @Test
+    void getAllAvailableProjects_ShouldThrowApiException_WhenServiceFails() {
+        PageableRequestDto pageableRequestDto = new PageableRequestDto();
+        pageableRequestDto.setPage(0);
+        pageableRequestDto.setSize(10);
+        when(freelancerWorkflowService.getAllAvailableProjects(any(Pageable.class), any(ProjectFilterDto.class)))
+                .thenThrow(ApiException.builder()
+                        .message("Failed to fetch projects")
+                        .status(500)
+                        .build());
+
+        assertThatThrownBy(() -> publicController.getAllAvailableProjects(pageableRequestDto, new ProjectFilterDto()))
+                .isInstanceOf(ApiException.class)
+                .hasMessage("Failed to fetch projects");
+        verify(freelancerWorkflowService).getAllAvailableProjects(any(Pageable.class), any(ProjectFilterDto.class));
+        verifyNoMoreInteractions(freelancerWorkflowService);
+    }
 
     @Test
     void getProjectById_ShouldReturnProject_WhenProjectExists() {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/AdminWorkflowServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/AdminWorkflowServiceUnitTest.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -66,32 +70,36 @@ class AdminWorkflowServiceTest {
                 .build();
     }
 
-//    @Test
-//    void getAllPendingProjects_ReturnsListOfProjects() {
-//        List<Project> mockProjects = Arrays.asList(mockProject1, mockProject2);
-//        when(projectService.getProjectsByStatuses(Collections.singletonList(ProjectStatus.PENDING)))
-//                .thenReturn(mockProjects);
-//
-//        List<ProjectDto> result = adminWorkflowService.getAllPendingProjects();
-//
-//        assertThat(result).hasSize(2);
-//        assertThat(result.get(0).getId()).isEqualTo(mockProject1.getId());
-//        assertThat(result.get(0).getTitle()).isEqualTo(mockProject1.getTitle());
-//        assertThat(result.get(1).getId()).isEqualTo(mockProject2.getId());
-//        assertThat(result.get(1).getTitle()).isEqualTo(mockProject2.getTitle());
-//        verify(projectService).getProjectsByStatuses(Collections.singletonList(ProjectStatus.PENDING));
-//    }
+    @Test
+    void getAllPendingProjects_ReturnsPageOfProjects() {
+        List<Project> mockProjects = Arrays.asList(mockProject1, mockProject2);
+        Page<Project> mockProjectPage = new PageImpl<>(mockProjects);
 
-//    @Test
-//    void getAllPendingProjects_WhenNoProjects_ReturnsEmptyList() {
-//        when(projectService.getProjectsByStatuses(Collections.singletonList(ProjectStatus.PENDING)))
-//                .thenReturn(Collections.emptyList());
-//
-//        List<ProjectDto> result = adminWorkflowService.getAllPendingProjects();
-//
-//        assertThat(result).isEmpty();
-//        verify(projectService).getProjectsByStatuses(Collections.singletonList(ProjectStatus.PENDING));
-//    }
+        when(projectService.getProjectsByStatuses(eq(Collections.singletonList(ProjectStatus.PENDING)), any(Pageable.class)))
+                .thenReturn(mockProjectPage);
+
+        Page<ProjectDto> result = adminWorkflowService.getAllPendingProjects(Pageable.unpaged());
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(mockProject1.getId());
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo(mockProject1.getTitle());
+        assertThat(result.getContent().get(1).getId()).isEqualTo(mockProject2.getId());
+        assertThat(result.getContent().get(1).getTitle()).isEqualTo(mockProject2.getTitle());
+        verify(projectService).getProjectsByStatuses(eq(Collections.singletonList(ProjectStatus.PENDING)), any(Pageable.class));
+    }
+
+    @Test
+    void getAllPendingProjects_WhenNoProjects_ReturnsEmptyPage() {
+        Page<Project> emptyPage = Page.empty();
+        when(projectService.getProjectsByStatuses(eq(Collections.singletonList(ProjectStatus.PENDING)), any(Pageable.class)))
+                .thenReturn(emptyPage);
+
+        Page<ProjectDto> result = adminWorkflowService.getAllPendingProjects(Pageable.unpaged());
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(projectService).getProjectsByStatuses(eq(Collections.singletonList(ProjectStatus.PENDING)), any(Pageable.class));
+    }
 
     @Test
     void approveProject_Success() {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/ClientWorkflowServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/ClientWorkflowServiceUnitTest.java
@@ -21,6 +21,9 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -169,26 +172,32 @@ class ClientWorkflowServiceTest {
                 .hasMessage("You are not authorized to remove this project");
     }
 
-//    @Test
-//    void getAllClientProjects_Success() {
-//        List<Project> projects = Arrays.asList(mockProject);
-//        when(projectService.getProjectsByClientId(mockClient.getId())).thenReturn(projects);
-//
-//        List<ProjectDto> result = clientWorkflowService.getAllClientProjects(mockClient);
-//
-//        assertThat(result).hasSize(1);
-//        assertThat(result.get(0).getId()).isEqualTo(mockProject.getId());
-//        assertThat(result.get(0).getTitle()).isEqualTo(mockProject.getTitle());
-//    }
+    @Test
+    void getAllClientProjects_Success() {
+        Page<Project> projectPage = new PageImpl<>(List.of(mockProject));
+        when(projectService.getProjectsByClientId(eq(mockClient.getId()), any(Pageable.class)))
+                .thenReturn(projectPage);
 
-//    @Test
-//    void getAllClientProjects_WhenNoProjects_ReturnsEmptyList() {
-//        when(projectService.getProjectsByClientId(mockClient.getId())).thenReturn(Collections.emptyList());
-//
-//        List<ProjectDto> result = clientWorkflowService.getAllClientProjects(mockClient);
-//
-//        assertThat(result).isEmpty();
-//    }
+        Page<ProjectDto> result = clientWorkflowService.getAllClientProjects(mockClient, Pageable.unpaged());
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(mockProject.getId());
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo(mockProject.getTitle());
+        verify(projectService).getProjectsByClientId(eq(mockClient.getId()), any(Pageable.class));
+    }
+
+    @Test
+    void getAllClientProjects_WhenNoProjects_ReturnsEmptyList() {
+        Page<Project> emptyPage = Page.empty();
+        when(projectService.getProjectsByClientId(eq(mockClient.getId()), any(Pageable.class)))
+                .thenReturn(emptyPage);
+
+        Page<ProjectDto> result = clientWorkflowService.getAllClientProjects(mockClient, Pageable.unpaged());
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(projectService).getProjectsByClientId(eq(mockClient.getId()), any(Pageable.class));
+    }
 
     @Test
     void getAllApplicationsToProject_WhenOwner_Success() {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/FreelancerWorkflowServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/FreelancerWorkflowServiceUnitTest.java
@@ -2,6 +2,7 @@ package com.quolance.quolance_api.unit.services.business_workflow;
 
 import com.quolance.quolance_api.dtos.application.ApplicationCreateDto;
 import com.quolance.quolance_api.dtos.application.ApplicationDto;
+import com.quolance.quolance_api.dtos.project.ProjectFilterDto;
 import com.quolance.quolance_api.dtos.project.ProjectPublicDto;
 import com.quolance.quolance_api.entities.Application;
 import com.quolance.quolance_api.entities.Profile;
@@ -28,6 +29,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -183,40 +185,39 @@ class FreelancerWorkflowServiceTest {
         assertThat(results).isEmpty();
     }
 
-//    @Test
-//    void getAllAvailableProjects_FiltersExpiredClosedProjects() {
-//        Project expiredProject = Project.builder()
-//                .id(2L)
-//                .projectStatus(ProjectStatus.CLOSED)
-//                .visibilityExpirationDate(LocalDate.now().minusDays(1))
-//                .build();
-//
-//        Project activeProject = Project.builder()
-//                .id(3L)
-//                .projectStatus(ProjectStatus.OPEN)
-//                .visibilityExpirationDate(LocalDate.now().plusDays(7))
-//                .build();
-//
-//        Project closedButVisibleProject = Project.builder()
-//                .id(4L)
-//                .projectStatus(ProjectStatus.CLOSED)
-//                .visibilityExpirationDate(LocalDate.now().plusDays(2))
-//                .build();
-//
-//        List<Project> mockProjects = new ArrayList<>();
-//        mockProjects.add(activeProject);
-//        mockProjects.add(expiredProject);
-//        mockProjects.add(closedButVisibleProject);
-//
-//        when(projectService.getProjectsByStatuses(List.of(ProjectStatus.OPEN, ProjectStatus.CLOSED)))
-//                .thenReturn(mockProjects);
-//
-//        List<ProjectPublicDto> results = freelancerWorkflowService.getAllAvailableProjects();
-//
-//        assertThat(results).hasSize(2);
-//        assertThat(results.stream().map(ProjectPublicDto::getId))
-//                .containsExactlyInAnyOrder(activeProject.getId(), closedButVisibleProject.getId());
-//    }
+    @Test
+    void getAllAvailableProjects_FiltersExpiredClosedProjects() {
+        Project expiredProject = Project.builder()
+                .id(2L)
+                .projectStatus(ProjectStatus.CLOSED)
+                .visibilityExpirationDate(LocalDate.now().minusDays(1))
+                .build();
+
+        Project activeProject = Project.builder()
+                .id(3L)
+                .projectStatus(ProjectStatus.OPEN)
+                .visibilityExpirationDate(LocalDate.now().plusDays(7))
+                .build();
+
+        Project closedButVisibleProject = Project.builder()
+                .id(4L)
+                .projectStatus(ProjectStatus.CLOSED)
+                .visibilityExpirationDate(LocalDate.now().plusDays(2))
+                .build();
+
+        List<Project> mockProjects = List.of(activeProject, closedButVisibleProject);
+        Page<Project> mockPage = new PageImpl<>(mockProjects);
+        Pageable pageable = PageRequest.of(0, 10);
+        ProjectFilterDto filters = new ProjectFilterDto();
+
+        when(projectService.findAllWithFilters(any(Specification.class), eq(pageable))).thenReturn(mockPage);
+        Page<ProjectPublicDto> results = freelancerWorkflowService.getAllAvailableProjects(pageable, filters);
+
+        assertThat(results.getContent()).hasSize(2);
+        assertThat(results.getContent().stream().map(ProjectPublicDto::getId))
+                .containsExactlyInAnyOrder(activeProject.getId(), closedButVisibleProject.getId());
+        verify(projectService).findAllWithFilters(any(Specification.class), eq(pageable));
+    }
 
     @Test
     void getProject_Success() {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/entity_services/ApplicationServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/entity_services/ApplicationServiceUnitTest.java
@@ -12,6 +12,10 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -100,27 +104,32 @@ class ApplicationServiceTest {
         assertThat(result).isEqualTo(mockApplication);
     }
 
-//    @Test
-//    void getAllApplicationsByFreelancerId_Success() {
-//        List<Application> applications = Arrays.asList(mockApplication);
-//        when(applicationRepository.findApplicationsByFreelancerId(1L)).thenReturn(applications);
-//
-//        List<Application> result = applicationService.getAllApplicationsByFreelancerId(1L);
-//
-//        assertThat(result).hasSize(1);
-//        assertThat(result).containsExactly(mockApplication);
-//    }
+    @Test
+    void getAllApplicationsByFreelancerId_Success() {
+        List<Application> applications = List.of(mockApplication);
+        Page<Application> expectedPage = new PageImpl<>(applications);
 
-//    @Test
-//    void getAllApplicationsByProjectId_Success() {
-//        List<Application> applications = Arrays.asList(mockApplication);
-//        when(applicationRepository.findApplicationsByProjectId(1L)).thenReturn(applications);
-//
-//        List<Application> result = applicationService.getAllApplicationsByProjectId(1L);
-//
-//        assertThat(result).hasSize(1);
-//        assertThat(result).containsExactly(mockApplication);
-//    }
+        when(applicationRepository.findApplicationsByFreelancerId(eq(1L), any(Pageable.class)))
+                .thenReturn(expectedPage);
+
+        Page<Application> result = applicationService.getAllApplicationsByFreelancerId(1L, Pageable.unpaged());
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent()).containsExactly(mockApplication);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(applicationRepository).findApplicationsByFreelancerId(eq(1L), any(Pageable.class));
+    }
+
+    @Test
+    void getAllApplicationsByProjectId_Success() {
+        List<Application> applications = Arrays.asList(mockApplication);
+        when(applicationRepository.findApplicationsByProjectId(1L)).thenReturn(applications);
+
+        List<Application> result = applicationService.getAllApplicationsByProjectId(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result).containsExactly(mockApplication);
+    }
 
     @Test
     void updateApplicationStatus_Success_ToAccepted() {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/entity_services/ProjectServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/entity_services/ProjectServiceUnitTest.java
@@ -18,6 +18,10 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -117,28 +121,39 @@ class ProjectServiceTest {
         assertThat(result).containsExactly(mockProject);
     }
 
-//    @Test
-//    void getProjectsByStatuses_Success() {
-//        List<Project> projects = Arrays.asList(mockProject);
-//        List<ProjectStatus> statuses = Arrays.asList(ProjectStatus.PENDING, ProjectStatus.OPEN);
-//        when(projectRepository.findProjectsByProjectStatusIn(statuses)).thenReturn(projects);
-//
-//        List<Project> result = projectService.getProjectsByStatuses(statuses);
-//
-//        assertThat(result).hasSize(1);
-//        assertThat(result).containsExactly(mockProject);
-//    }
+    @Test
+    void getProjectsByStatuses_Success() {
+        List<Project> projects = List.of(mockProject);
+        List<ProjectStatus> statuses = Arrays.asList(ProjectStatus.PENDING, ProjectStatus.OPEN);
+        Page<Project> expectedPage = new PageImpl<>(projects);
 
-//    @Test
-//    void getProjectsByClientId_Success() {
-//        List<Project> projects = Arrays.asList(mockProject);
-//        when(projectRepository.findProjectsByClientId(1L)).thenReturn(projects);
-//
-//        List<Project> result = projectService.getProjectsByClientId(1L);
-//
-//        assertThat(result).hasSize(1);
-//        assertThat(result).containsExactly(mockProject);
-//    }
+        when(projectRepository.findProjectsByProjectStatusIn(eq(statuses), any(Pageable.class)))
+                .thenReturn(expectedPage);
+
+        Page<Project> result = projectService.getProjectsByStatuses(statuses, Pageable.unpaged());
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent()).containsExactly(mockProject);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(projectRepository).findProjectsByProjectStatusIn(eq(statuses), any(Pageable.class));
+
+    }
+
+    @Test
+    void getProjectsByClientId_Success() {
+        List<Project> projects = List.of(mockProject);
+        Page<Project> expectedPage = new PageImpl<>(projects);
+
+        when(projectRepository.findProjectsByClientId(eq(1L), any(Pageable.class)))
+                .thenReturn(expectedPage);
+
+        Page<Project> result = projectService.getProjectsByClientId(1L, Pageable.unpaged());
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent()).containsExactly(mockProject);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(projectRepository).findProjectsByClientId(eq(1L), any(Pageable.class));
+    }
 
     @Test
     void updateProjectStatus_Success_ToOpen() {


### PR DESCRIPTION
### Overview

This PR addresses the uncommented and outdated tests for the `FreelancerController`, `ClientController`,`PublicController` and their corresponding ServiceTest Classes updating them to make them work with the recently modified methods and pagination logic. 

### Changes

- Uncommented and updated tests for methods impacted by pagination.
- Refactored unit and integration tests to match the updated method signatures in:
  - **FreelancerController** 
  - **ClientController**
  - **PublicController** 
- Adjusted other service tests for methods using pagination.

### Implementation Details

The updated tests now validate the following:

- Pagination parameters such as page number, size, and sorting.
- Correct interaction between controllers, services, and repositories for paginated results.
- Proper filtering and business logic applied to paginated queries.

### Example Before 
![image](https://github.com/user-attachments/assets/5906f528-c007-4375-b761-e276e96696b1)

### Example After
![image](https://github.com/user-attachments/assets/cb23e76d-c637-4cc9-aed4-e5a65ddb9a3f)
