### PR TITLE
feat: add freelancer catalog for client for #268

### DIFF
--- a/QuolanceAPI.postman_collection.json
+++ b/QuolanceAPI.postman_collection.json
@@ -464,6 +464,28 @@
 					"response": []
 				},
 				{
+					"name": "Get All Available Freelancers",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8081/api/client/projects/all",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"api",
+								"client",
+								"projects",
+								"all"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Select Freelancer for Project",
 					"request": {
 						"method": "POST",

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
@@ -4,14 +4,14 @@ import com.quolance.quolance_api.dtos.PageResponseDto;
 import com.quolance.quolance_api.dtos.PageableRequestDto;
 import com.quolance.quolance_api.dtos.profile.FreelancerProfileDto;
 import com.quolance.quolance_api.dtos.application.ApplicationDto;
-import com.quolance.quolance_api.dtos.project.ProjectCreateDto;
-import com.quolance.quolance_api.dtos.project.ProjectDto;
-import com.quolance.quolance_api.dtos.project.ProjectUpdateDto;
+import com.quolance.quolance_api.dtos.profile.FreelancerProfileFilterDto;
+import com.quolance.quolance_api.dtos.project.*;
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.services.business_workflow.ApplicationProcessWorkflow;
 import com.quolance.quolance_api.services.business_workflow.ClientWorkflowService;
 import com.quolance.quolance_api.util.PaginationUtils;
 import com.quolance.quolance_api.util.SecurityUtil;
+import com.quolance.quolance_api.util.exceptions.ApiException;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -138,6 +138,29 @@ public class ClientController {
         User client = SecurityUtil.getAuthenticatedUser();
         applicationProcessWorkflow.rejectManyApplications(applicationIds, client);
         return ResponseEntity.ok("All selected freelancers rejected successfully");
+    }
+
+    @GetMapping("/freelancers/all")
+    @Operation(
+            summary = "View all available freelancers.",
+            description = "View all freelancers (as a client) based on the provided filters."
+    )
+    public ResponseEntity<Page<FreelancerProfileDto>> getAllAvailableFreelancers(
+            @Valid PageableRequestDto pageableRequest,
+            @Valid FreelancerProfileFilterDto filters) {
+
+        try {
+            Page<FreelancerProfileDto> freelancersPage = clientWorkflowService.getAllAvailableFreelancers(
+                    pageableRequest.toPageRequest(),
+                    filters
+            );
+            return ResponseEntity.ok(freelancersPage);
+        } catch (ApiException e) {
+            System.out.println(e.getMessage());
+
+        }
+
+        return null;
     }
 
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
@@ -148,19 +148,11 @@ public class ClientController {
     public ResponseEntity<Page<FreelancerProfileDto>> getAllAvailableFreelancers(
             @Valid PageableRequestDto pageableRequest,
             @Valid FreelancerProfileFilterDto filters) {
-
-        try {
             Page<FreelancerProfileDto> freelancersPage = clientWorkflowService.getAllAvailableFreelancers(
                     pageableRequest.toPageRequest(),
                     filters
             );
             return ResponseEntity.ok(freelancersPage);
-        } catch (ApiException e) {
-            System.out.println(e.getMessage());
-
-        }
-
-        return null;
     }
 
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/profile/FreelancerProfileFilterDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/profile/FreelancerProfileFilterDto.java
@@ -1,0 +1,17 @@
+package com.quolance.quolance_api.dtos.profile;
+
+import com.quolance.quolance_api.entities.enums.Availability;
+import com.quolance.quolance_api.entities.enums.FreelancerExperienceLevel;
+import com.quolance.quolance_api.entities.enums.Tag;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Set;
+@Getter
+@Setter
+public class FreelancerProfileFilterDto {
+    private String searchName;
+    private FreelancerExperienceLevel experienceLevel;
+    private Availability availability;
+    private Set<Tag> skills;
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/repositories/UserRepository.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/repositories/UserRepository.java
@@ -1,14 +1,16 @@
 package com.quolance.quolance_api.repositories;
 
+import com.quolance.quolance_api.entities.Project;
 import com.quolance.quolance_api.entities.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificationExecutor<User> {
 
     Optional<User> findByEmail(String email);
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/business_workflow/ClientWorkflowService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/business_workflow/ClientWorkflowService.java
@@ -2,9 +2,8 @@ package com.quolance.quolance_api.services.business_workflow;
 
 import com.quolance.quolance_api.dtos.profile.FreelancerProfileDto;
 import com.quolance.quolance_api.dtos.application.ApplicationDto;
-import com.quolance.quolance_api.dtos.project.ProjectCreateDto;
-import com.quolance.quolance_api.dtos.project.ProjectDto;
-import com.quolance.quolance_api.dtos.project.ProjectUpdateDto;
+import com.quolance.quolance_api.dtos.profile.FreelancerProfileFilterDto;
+import com.quolance.quolance_api.dtos.project.*;
 import com.quolance.quolance_api.entities.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,4 +22,7 @@ public interface ClientWorkflowService {
     List<ApplicationDto> getAllApplicationsToProject(Long projectId, User client);
 
     ProjectDto updateProject(Long projectId, ProjectUpdateDto projectUpdateDto, User client);
+
+    Page<FreelancerProfileDto> getAllAvailableFreelancers(Pageable pageable, FreelancerProfileFilterDto filters);
+
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/business_workflow/impl/ClientWorkflowServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/business_workflow/impl/ClientWorkflowServiceImpl.java
@@ -110,10 +110,15 @@ public class ClientWorkflowServiceImpl implements ClientWorkflowService {
 
             if (filters != null) {
                 if (filters.getSearchName() != null && !filters.getSearchName().trim().isEmpty()) {
-                    predicates.add(criteriaBuilder.like(
-                            criteriaBuilder.lower(root.get("username")),
-                            "%" + filters.getSearchName().toLowerCase() + "%"
-                    ));
+                    String searchPattern = "%" + filters.getSearchName().toLowerCase() + "%";
+
+                    Predicate firstNamePredicate = criteriaBuilder.like(
+                            criteriaBuilder.lower(root.get("firstName")), searchPattern);
+                    Predicate lastNamePredicate = criteriaBuilder.like(
+                            criteriaBuilder.lower(root.get("lastName")), searchPattern);
+
+                    Predicate combinedPredicate = criteriaBuilder.or(firstNamePredicate, lastNamePredicate);
+                    predicates.add(combinedPredicate);
                 }
 
                 if (filters.getExperienceLevel() != null) {

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/UserService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/UserService.java
@@ -1,8 +1,12 @@
 package com.quolance.quolance_api.services.entity_services;
 
 import com.quolance.quolance_api.dtos.*;
+import com.quolance.quolance_api.entities.Project;
 import com.quolance.quolance_api.entities.User;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.util.Optional;
 
@@ -29,4 +33,7 @@ public interface UserService {
     UserResponseDto createAdmin(@Valid CreateAdminRequestDto request);
 
     void updateProfilePicture(User user, String photoUrl);
+
+    Page<User> findAllWithFilters(Specification<User> spec, Pageable pageable);
+
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
@@ -15,6 +15,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.jobrunr.scheduling.BackgroundJobRequest;
 import org.jobrunr.scheduling.BackgroundJob;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +61,11 @@ public class UserServiceImpl implements UserService {
     public void updateProfilePicture(User user, String photoUrl) {
         user.setProfileImageUrl(photoUrl);
         userRepository.save(user);
+    }
+
+    @Override
+    public Page<User> findAllWithFilters(Specification<User> spec, Pageable pageable) {
+        return userRepository.findAll(spec, pageable);
     }
 
     @Override


### PR DESCRIPTION
## Overview  
This PR implements a new endpoint in the `ClientController` to allow clients to retrieve a catalog of freelancer profiles. The catalog supports filtering by  `experienceLevel`, `availability`, and `skills`.  

## Changes  
- Added a new endpoint in `ClientController` to retrieve freelancer catalogs.  
- Implemented filtering logic in the service layer to support dynamic queries based on the provided filters (`experienceLevel`, `availability`, and `skills`).  
- Updated repository methods to accommodate query parameters for filtering freelancer profiles.  


## New Endpoint  
- **ClientController**: `api/client/freelancers/all`  

## Implementation Details  
- `experienceLevel`: Filter freelancers by their experience level (e.g., JUNIOR, INTERMEDIATE, EXPERT).  
- `availability`: Filter by freelancer availability status.  
- `skills`: Filter by specific skills, can be filtered with multiple.  

Filters are optional, and the endpoint can return all freelancer profiles if no filters are provided.  

## Usage Example  
`GET api/client/freelancers/all?searchName=John&experienceLevel=JUNIOR&availability=FULL_TIME`

Closes #268