### PR TITLE
feat: #249 Make UI for leaving reactions on a post

### DIFF
--- a/quolance-ui/package-lock.json
+++ b/quolance-ui/package-lock.json
@@ -38,7 +38,7 @@
         "react-countup": "^6.5.3",
         "react-dom": "^18",
         "react-hook-form": "^7.53.1",
-        "react-icons": "^5.1.0",
+        "react-icons": "^5.4.0",
         "react-intersection-observer": "^9.8.2",
         "react-odometerjs": "^3.1.3",
         "react-quill-new": "^3.3.3",
@@ -15676,9 +15676,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
-      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/quolance-ui/package.json
+++ b/quolance-ui/package.json
@@ -49,7 +49,7 @@
     "react-countup": "^6.5.3",
     "react-dom": "^18",
     "react-hook-form": "^7.53.1",
-    "react-icons": "^5.1.0",
+    "react-icons": "^5.4.0",
     "react-intersection-observer": "^9.8.2",
     "react-odometerjs": "^3.1.3",
     "react-quill-new": "^3.3.3",

--- a/quolance-ui/src/api/blog-api.ts
+++ b/quolance-ui/src/api/blog-api.ts
@@ -34,3 +34,44 @@ export const useCreateBlogPost = (options?: {
     });
 };
 
+export interface ReactionResponseDto {
+  id: number;
+  reactionType: string;
+  userId: number;
+  userName: string;
+  blogPostId: number;
+}
+
+
+export const useGetReactionsByPostId = (postId: number, options?: {
+  onSuccess?: (data: ReactionResponseDto[]) => void;
+  onError?: (error: HttpErrorResponse) => void;
+}) => {
+  return useQuery<ReactionResponseDto[], HttpErrorResponse>({
+    queryKey: ['post-reactions', postId],
+    queryFn: async () => {
+      const response = await httpClient.get(`/api/blog-posts/reactions/post/${postId}`);
+      return response.data;
+    },
+    enabled: !!postId, // Only fetch if postId is defined
+    ...options,
+  });
+};
+
+export interface ReactionRequestDto {
+  reactionType: string;
+  blogPostId: number;
+}
+
+export const useReactToPost = (options?: {
+  onSuccess?: (data: ReactionResponseDto) => void;
+  onError?: (error: HttpErrorResponse) => void;
+}) => {
+  return useMutation<ReactionResponseDto, HttpErrorResponse, ReactionRequestDto>({
+    mutationFn: async (reactionRequest) => {
+      const response = await httpClient.post('/api/blog-posts/reactions/post', reactionRequest);
+      return response.data;
+    },
+    ...options,
+  });
+};

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import Image from "next/image";
 import icon from "@/public/images/freelancer_default_icon.png";
 import PostReaction from "./PostReaction";
-import { update } from "node_modules/cypress/types/lodash";
 
 interface ReactionState {
     [key: string]: { count: number; userReacted: boolean };

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -40,32 +40,32 @@ const PostCard: React.FC<PostCardProps> = ({
 
     const handleReactionClick = (reactionType: string) => {
         setReactions((prevReactions) => {
-            const newReactions = { ...prevReactions };
+            const oldReactions = { ...prevReactions };
 
-            if (newReactions[reactionType].userReacted){
+            if (oldReactions[reactionType].userReacted){
                 return {
-                    ...newReactions,
+                    ...oldReactions,
                     [reactionType]: {
-                        ...newReactions[reactionType],
-                        count: newReactions[reactionType].count - 1,
+                        ...oldReactions[reactionType],
+                        count: oldReactions[reactionType].count - 1,
                         userReacted: false,
                 }}
             } else {
-                const updatedReactions = Object.keys(newReactions).reduce((reaction, key) => {
-                    if (key === reactionType) {
-                        reaction[key] = {
-                            count: newReactions[key].count + 1,
+                const updatedReactions = Object.keys(oldReactions).reduce((acc, reaction) => {
+                    if (reaction === reactionType) {
+                        acc[reaction] = {
+                            count: oldReactions[reaction].count + 1,
                             userReacted: true,
                         };
-                    } else if (newReactions[key].userReacted) {
-                        reaction[key] = {
-                            count: newReactions[key].count - 1,
+                    } else if (oldReactions[reaction].userReacted) {
+                        acc[reaction] = {
+                            count: oldReactions[reaction].count - 1,
                             userReacted: false,
                         };
                     } else {
-                        reaction[key] = newReactions[key];
+                        acc[reaction] = oldReactions[reaction];
                     }
-                    return reaction;
+                    return acc;
                 }, {} as ReactionState);
                 return updatedReactions;
             }

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -1,150 +1,148 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import icon from "@/public/images/freelancer_default_icon.png";
 import PostReaction from "./PostReaction";
+import { useGetReactionsByPostId, useReactToPost } from "@/api/blog-api";
+import { useAuthGuard } from "@/api/auth-api";
 
 interface ReactionState {
     [key: string]: { count: number; userReacted: boolean };
-}
-
-interface PostCardProps {
+  }
+  
+  interface PostCardProps {
     id: number;
     title: string;
     content: string;
     authorName: string;
     dateCreated: string;
-    comments: string[];
-}
-
-const PostCard: React.FC<PostCardProps> = ({ 
-    id, 
-    title, 
-    content, 
-    authorName, 
-    dateCreated, 
-    comments 
-}) => {
+  }
+  
+  const PostCard: React.FC<PostCardProps> = ({
+    id,
+    title,
+    content,
+    authorName,
+    dateCreated,
+  }) => {
     const [isExpanded, setIsExpanded] = useState(false);
-
-    const [reactions, setReactions] = useState<ReactionState>({
-        like: { count: 5, userReacted: false },
-        love: { count: 2, userReacted: true },
-        laugh: { count: 3, userReacted: false },
-        shocked: { count: 1, userReacted: false },
-        sad: { count: 0, userReacted: false },
-        angry: { count: 0, userReacted: false },
-    });
-
-    const handleReactionClick = (reactionType: string) => {
-        setReactions((prevReactions) => {
-            const oldReactions = { ...prevReactions };
-
-            if (oldReactions[reactionType].userReacted){
-                return {
-                    ...oldReactions,
-                    [reactionType]: {
-                        ...oldReactions[reactionType],
-                        count: oldReactions[reactionType].count - 1,
-                        userReacted: false,
-                }}
-            } else {
-                const updatedReactions = Object.keys(oldReactions).reduce((acc, reaction) => {
-                    if (reaction === reactionType) {
-                        acc[reaction] = {
-                            count: oldReactions[reaction].count + 1,
-                            userReacted: true,
-                        };
-                    } else if (oldReactions[reaction].userReacted) {
-                        acc[reaction] = {
-                            count: oldReactions[reaction].count - 1,
-                            userReacted: false,
-                        };
-                    } else {
-                        acc[reaction] = oldReactions[reaction];
-                    }
-                    return acc;
-                }, {} as ReactionState);
-                return updatedReactions;
-            }
+    const [reactions, setReactions] = useState<ReactionState | null>(null);
+  
+    const { data: reactionData } = useGetReactionsByPostId(id);
+    const { mutate: reactToPost } = useReactToPost();
+    const { user } = useAuthGuard({ middleware: "auth" });
+  
+    // Initialize reactions when data is fetched
+    useEffect(() => {
+      if (reactionData) {
+        const initialReactions: ReactionState = {
+          like: { count: 0, userReacted: false },
+          love: { count: 0, userReacted: false },
+          haha: { count: 0, userReacted: false },
+          wow: { count: 0, userReacted: false },
+          sad: { count: 0, userReacted: false },
+          angry: { count: 0, userReacted: false },
+        };
+  
+        reactionData.forEach((reaction) => {
+          const { reactionType, userName } = reaction;
+          initialReactions[reactionType.toLowerCase()].count += 1;
+          if (userName === user?.username) { // Mark as filled if reacted by current user
+            initialReactions[reactionType.toLowerCase()].userReacted = true;
+          }
         });
+  
+        setReactions(initialReactions);
+      }
+    }, [reactionData, user]);
+  
+    const handleReactionClick = (reactionType: string) => {
+      if (!reactions) return;
+  
+      const userReacted = reactions[reactionType].userReacted;
+  
+      const updatedReactions = Object.keys(reactions).reduce((acc, key) => {
+        acc[key] = { ...reactions[key] };
+  
+        if (key === reactionType) {
+          acc[key].userReacted = !userReacted;
+          acc[key].count += userReacted ? -1 : 1;
+        } else if (reactions[key].userReacted) {
+          acc[key].userReacted = false;
+          acc[key].count -= 1;
+        }
+  
+        return acc;
+      }, {} as ReactionState);
+  
+      setReactions(updatedReactions);
+  
+      // Post the reaction to the backend
+      reactToPost({ reactionType: reactionType.toUpperCase(), blogPostId: id });
     };
-
+  
     const toggleExpand = () => setIsExpanded(!isExpanded);
-
+  
     return (
-        <div className="bg-white shadow-md rounded-md">
-            {/* User Info */}
-            <div className="bg-slate-300 w-full rounded-t-md">
-                <div className="flex items-center mb-4 ml-5 py-5">
-                    <Image
-                        alt={`${authorName}'s profile`}
-                        src={icon} // profilePicture
-                        width={48}
-                        height={48}
-                        className="rounded-full object-cover"
-                    />
-                    <div className="ml-4">
-                        <p className="font-semibold text-gray-800">{authorName}</p>
-                        {/* <p className="text-sm text-gray-500">{fieldOfWork}</p> */}
-                    </div>
-                </div>
+      <div className="bg-white shadow-md rounded-md">
+        {/* User Info */}
+        <div className="bg-slate-300 w-full rounded-t-md">
+          <div className="flex items-center mb-4 ml-5 py-5">
+            <Image
+              alt={`${authorName}'s profile`}
+              src={icon}
+              width={48}
+              height={48}
+              className="rounded-full object-cover"
+            />
+            <div className="ml-4">
+              <p className="font-semibold text-gray-800">{authorName}</p>
             </div>
-
-            {/* Post Content */}
-            <div className="ml-5 mr-5 mb-5">
-                <div className="flex justify-between">
-                    <h3 className="text-md font-semibold text-gray-800">{title}</h3>
-                    <span className="text-sm text-gray-500">
-                        {new Intl.DateTimeFormat("en-US", {
-                            year: "numeric",
-                            month: "long",
-                            day: "numeric",
-                            }).format(new Date(dateCreated))}
-                    </span>
-                </div>
-                <div className={`mt-2 ${!isExpanded ? "line-clamp-3" : ""}`}>
-                    <p className="text-gray-700">{content}</p>
-                </div>
-
-                {content.length > 300 && (
-                    <button
-                    onClick={toggleExpand}
-                    className="text-blue-500 text-sm mt-2 focus:outline-none"
-                >
-                    {isExpanded ? "Read less" : "Read more"}
-                </button>
-                )}
-                
-                {/* Tags */}
-                {/* <div className="mt-4">
-                    <p className="text-sm font-semibold text-grey-800 mb-2">Tags: </p>
-                    {tags.map((tag, index) => (
-                        <span
-                            key={index}
-                            className="px-2 py-1 bg-gray-200 text-gray-700 rounded-full text-xs"
-                        >
-                            {tag}
-                        </span>
-                    ))}
-                </div> */}
-
-                {/* Reaction Buttons */}
-                <div className="mt-4 flex items-center gap-1">
-                    {Object.keys(reactions).map((reaction) => (
-                        <PostReaction
-                            key={reaction}
-                            reaction={reaction}
-                            reactionCount={reactions[reaction].count}
-                            userReaction={reactions[reaction].userReacted}
-                            onReactionClick={() => handleReactionClick(reaction)}
-                        />
-                    ))}
-                </div>
-            </div>
+          </div>
         </div>
+  
+        {/* Post Content */}
+        <div className="ml-5 mr-5 mb-5">
+          <div className="flex justify-between">
+            <h3 className="text-md font-semibold text-gray-800">{title}</h3>
+            <span className="text-sm text-gray-500">
+              {new Intl.DateTimeFormat("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              }).format(new Date(dateCreated))}
+            </span>
+          </div>
+          <div className={`mt-2 ${!isExpanded ? "line-clamp-3" : ""}`}>
+            <p className="text-gray-700">{content}</p>
+          </div>
+  
+          {content.length > 300 && (
+            <button
+              onClick={toggleExpand}
+              className="text-blue-500 text-sm mt-2 focus:outline-none"
+            >
+              {isExpanded ? "Read less" : "Read more"}
+            </button>
+          )}
+  
+          {/* Reaction Buttons */}
+          <div className="mt-4 flex items-center gap-1">
+            {reactions &&
+              Object.keys(reactions).map((reaction) => (
+                <PostReaction
+                  key={reaction}
+                  reaction={reaction}
+                  reactionCount={reactions[reaction].count}
+                  userReaction={reactions[reaction].userReacted}
+                  onReactionClick={() => handleReactionClick(reaction)}
+                />
+              ))}
+          </div>
+        </div>
+      </div>
     );
-};
-
-export default PostCard;
+  };
+  
+  export default PostCard;

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -3,6 +3,12 @@
 import React, { useState } from "react";
 import Image from "next/image";
 import icon from "@/public/images/freelancer_default_icon.png";
+import PostReaction from "./PostReaction";
+import { update } from "node_modules/cypress/types/lodash";
+
+interface ReactionState {
+    [key: string]: { count: number; userReacted: boolean };
+}
 
 interface PostCardProps {
     id: number;
@@ -13,8 +19,58 @@ interface PostCardProps {
     comments: string[];
 }
 
-const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dateCreated, comments }) => {
+const PostCard: React.FC<PostCardProps> = ({ 
+    id, 
+    title, 
+    content, 
+    authorName, 
+    dateCreated, 
+    comments 
+}) => {
     const [isExpanded, setIsExpanded] = useState(false);
+
+    const [reactions, setReactions] = useState<ReactionState>({
+        like: { count: 5, userReacted: false },
+        love: { count: 2, userReacted: true },
+        laugh: { count: 3, userReacted: false },
+        shocked: { count: 1, userReacted: false },
+        sad: { count: 0, userReacted: false },
+        angry: { count: 0, userReacted: false },
+    });
+
+    const handleReactionClick = (reactionType: string) => {
+        setReactions((prevReactions) => {
+            const newReactions = { ...prevReactions };
+
+            if (newReactions[reactionType].userReacted){
+                return {
+                    ...newReactions,
+                    [reactionType]: {
+                        ...newReactions[reactionType],
+                        count: newReactions[reactionType].count - 1,
+                        userReacted: false,
+                }}
+            } else {
+                const updatedReactions = Object.keys(newReactions).reduce((reaction, key) => {
+                    if (key === reactionType) {
+                        reaction[key] = {
+                            count: newReactions[key].count + 1,
+                            userReacted: true,
+                        };
+                    } else if (newReactions[key].userReacted) {
+                        reaction[key] = {
+                            count: newReactions[key].count - 1,
+                            userReacted: false,
+                        };
+                    } else {
+                        reaction[key] = newReactions[key];
+                    }
+                    return reaction;
+                }, {} as ReactionState);
+                return updatedReactions;
+            }
+        });
+    };
 
     const toggleExpand = () => setIsExpanded(!isExpanded);
 
@@ -74,6 +130,19 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
                         </span>
                     ))}
                 </div> */}
+
+                {/* Reaction Buttons */}
+                <div className="mt-4 flex items-center gap-1">
+                    {Object.keys(reactions).map((reaction) => (
+                        <PostReaction
+                            key={reaction}
+                            reaction={reaction}
+                            reactionCount={reactions[reaction].count}
+                            userReaction={reactions[reaction].userReacted}
+                            onReactionClick={() => handleReactionClick(reaction)}
+                        />
+                    ))}
+                </div>
             </div>
         </div>
     );

--- a/quolance-ui/src/components/ui/blog/PostReaction.tsx
+++ b/quolance-ui/src/components/ui/blog/PostReaction.tsx
@@ -1,0 +1,55 @@
+"use-client";
+
+import React from "react";
+import { 
+    BiHeart, BiSolidHeart, 
+    BiHappyHeartEyes, BiSolidHappyHeartEyes, 
+    BiAngry, BiSolidAngry, 
+    BiLike, BiSolidLike, 
+    BiLaugh, BiSolidLaugh,
+    BiSad, BiSolidSad,
+    BiShocked, BiSolidShocked,
+} from "react-icons/bi";
+
+interface PostReactionProps {
+    reaction: string;
+    reactionCount: number;
+    userReaction: boolean; // If the user has reacted to the post (will determine if the icon is filled or not)
+    onReactionClick: () => void;
+}
+
+const PostReaction: React.FC<PostReactionProps> = ({ 
+    reaction, 
+    reactionCount, 
+    userReaction, 
+    onReactionClick, 
+}) => {
+    const renderReactionIcon = () => {
+        switch (reaction) {
+            case "like":
+                return userReaction ? <BiSolidLike /> : <BiLike />;
+            case "love":
+                return userReaction ? <BiSolidHeart /> : <BiHeart />;
+            case "laugh":
+                return userReaction ? <BiSolidLaugh /> : <BiLaugh />;
+            case "shocked":
+                return userReaction ? <BiSolidShocked /> : <BiShocked />;
+            case "sad":
+                return userReaction ? <BiSolidSad /> : <BiSad />;
+            case "angry":
+                return userReaction ? <BiSolidAngry /> : <BiAngry />;
+        }
+    }
+
+    return (
+        <button
+            onClick={onReactionClick}
+            className="flex items-center gap-1 px-2 py-1 text-gray-700 hover:text-blue-500 focus:outline-none"
+        >
+            {renderReactionIcon()}
+            <p className="ml-1">{reactionCount}</p>
+        </button>
+    );
+}
+
+export default PostReaction;

--- a/quolance-ui/src/components/ui/blog/PostReaction.tsx
+++ b/quolance-ui/src/components/ui/blog/PostReaction.tsx
@@ -32,13 +32,13 @@ const PostReaction: React.FC<PostReactionProps> = ({
         switch (reaction) {
             case "like":
               return userReaction ? (
-                <BiSolidLike {...commonProps} style={{ color: "#1500FF" }} />
+                <BiSolidLike {...commonProps} style={{ color: "#0218AF" }} />
               ) : (
                 <BiLike {...commonProps} />
               );
             case "love":
               return userReaction ? (
-                <BiSolidHeart {...commonProps} style={{ color: "#FF3300" }} />
+                <BiSolidHeart {...commonProps} style={{ color: "#AF0500" }} />
               ) : (
                 <BiHeart {...commonProps} />
               );

--- a/quolance-ui/src/components/ui/blog/PostReaction.tsx
+++ b/quolance-ui/src/components/ui/blog/PostReaction.tsx
@@ -42,13 +42,13 @@ const PostReaction: React.FC<PostReactionProps> = ({
               ) : (
                 <BiHeart {...commonProps} />
               );
-            case "laugh":
+            case "haha":
               return userReaction ? (
                 <BiSolidLaugh {...commonProps} style={{ color: "#DABC00" }} />
               ) : (
                 <BiLaugh {...commonProps} />
               );
-            case "shocked":
+            case "wow":
               return userReaction ? (
                 <BiSolidShocked {...commonProps} style={{ color: "#DABC00" }} />
               ) : (

--- a/quolance-ui/src/components/ui/blog/PostReaction.tsx
+++ b/quolance-ui/src/components/ui/blog/PostReaction.tsx
@@ -25,31 +25,58 @@ const PostReaction: React.FC<PostReactionProps> = ({
     onReactionClick, 
 }) => {
     const renderReactionIcon = () => {
+        const commonProps = {
+          size: 24,
+          style: { cursor: "pointer" },
+        };
         switch (reaction) {
             case "like":
-                return userReaction ? <BiSolidLike /> : <BiLike />;
+              return userReaction ? (
+                <BiSolidLike {...commonProps} style={{ color: "blue" }} />
+              ) : (
+                <BiLike {...commonProps} />
+              );
             case "love":
-                return userReaction ? <BiSolidHeart /> : <BiHeart />;
+              return userReaction ? (
+                <BiSolidHeart {...commonProps} style={{ color: "red" }} />
+              ) : (
+                <BiHeart {...commonProps} />
+              );
             case "laugh":
-                return userReaction ? <BiSolidLaugh /> : <BiLaugh />;
+              return userReaction ? (
+                <BiSolidLaugh {...commonProps} style={{ color: "yellow" }} />
+              ) : (
+                <BiLaugh {...commonProps} />
+              );
             case "shocked":
-                return userReaction ? <BiSolidShocked /> : <BiShocked />;
+              return userReaction ? (
+                <BiSolidShocked {...commonProps} style={{ color: "yellow" }} />
+              ) : (
+                <BiShocked {...commonProps} />
+              );
             case "sad":
-                return userReaction ? <BiSolidSad /> : <BiSad />;
+              return userReaction ? (
+                <BiSolidSad {...commonProps} style={{ color: "yellow" }} />
+              ) : (
+                <BiSad {...commonProps} />
+              );
             case "angry":
-                return userReaction ? <BiSolidAngry /> : <BiAngry />;
-        }
-    }
-
-    return (
-        <button
-            onClick={onReactionClick}
-            className="flex items-center gap-1 px-2 py-1 text-gray-700 hover:text-blue-500 focus:outline-none"
-        >
-            {renderReactionIcon()}
-            <p className="ml-1">{reactionCount}</p>
-        </button>
-    );
-}
-
-export default PostReaction;
+              return userReaction ? (
+                <BiSolidAngry {...commonProps} style={{ color: "yellow" }} />
+              ) : (
+                <BiAngry {...commonProps} />
+              );
+          }
+        };
+      
+        return (
+          <div className="flex items-center">
+            <button onClick={onReactionClick} className="focus:outline-none">
+              {renderReactionIcon()}
+            </button>
+            <p className="ml-1">{reactionCount}&nbsp;&nbsp;</p>
+          </div>
+        );
+      };
+      
+      export default PostReaction;

--- a/quolance-ui/src/components/ui/blog/PostReaction.tsx
+++ b/quolance-ui/src/components/ui/blog/PostReaction.tsx
@@ -32,37 +32,37 @@ const PostReaction: React.FC<PostReactionProps> = ({
         switch (reaction) {
             case "like":
               return userReaction ? (
-                <BiSolidLike {...commonProps} style={{ color: "blue" }} />
+                <BiSolidLike {...commonProps} style={{ color: "#1500FF" }} />
               ) : (
                 <BiLike {...commonProps} />
               );
             case "love":
               return userReaction ? (
-                <BiSolidHeart {...commonProps} style={{ color: "red" }} />
+                <BiSolidHeart {...commonProps} style={{ color: "#FF3300" }} />
               ) : (
                 <BiHeart {...commonProps} />
               );
             case "laugh":
               return userReaction ? (
-                <BiSolidLaugh {...commonProps} style={{ color: "yellow" }} />
+                <BiSolidLaugh {...commonProps} style={{ color: "#DABC00" }} />
               ) : (
                 <BiLaugh {...commonProps} />
               );
             case "shocked":
               return userReaction ? (
-                <BiSolidShocked {...commonProps} style={{ color: "yellow" }} />
+                <BiSolidShocked {...commonProps} style={{ color: "#DABC00" }} />
               ) : (
                 <BiShocked {...commonProps} />
               );
             case "sad":
               return userReaction ? (
-                <BiSolidSad {...commonProps} style={{ color: "yellow" }} />
+                <BiSolidSad {...commonProps} style={{ color: "#DABC00" }} />
               ) : (
                 <BiSad {...commonProps} />
               );
             case "angry":
               return userReaction ? (
-                <BiSolidAngry {...commonProps} style={{ color: "yellow" }} />
+                <BiSolidAngry {...commonProps} style={{ color: "#DABC00" }} />
               ) : (
                 <BiAngry {...commonProps} />
               );


### PR DESCRIPTION
### Pull Request: Integrate Reaction Functionality with Backend for Blog Posts

#### **Summary**
This PR fully integrates the reaction functionality for blog posts with the backend, enabling real-time updates and accurate reflection of user reactions. Users can now react to posts with various reactions such as "Like," "Love," "Laugh," "Shocked," "Sad," and "Angry." The backend ensures that reactions are tied to authenticated users and stored appropriately, while the frontend dynamically updates reaction counts and icons based on the data fetched from the backend.

---

#### **Key Changes**
1. **Backend Integration**
   - **Fetching Reactions**: 
     - Added the `useGetReactionsByPostId` hook to fetch reactions for each blog post from the `/api/blog-posts/reactions/post/{postId}` endpoint.
   - **Posting Reactions**: 
     - Added the `useReactToPost` hook to handle user reactions via the `/api/blog-posts/reactions/post` endpoint.
   - Reaction state is now directly derived from the backend, ensuring data consistency.

2. **`PostReaction` Component**
   - Displays individual reactions and their counts.
   - Supports hollow and solid icons with custom colors based on the reaction type.
   - Updated to reflect whether the currently logged-in user has reacted to the post (based on the `userName` property from the backend).

3. **`PostCard` Updates**
   - **Reaction Section**:
     - Dynamically renders all `PostReaction` components with data fetched from the backend.
     - Reactions are initialized based on the `userName` field to determine if the current user has already reacted.
   - **Reaction Logic**:
     - Clicking on a reaction icon toggles its state:
       - If the user hasn't reacted yet, the selected reaction is added (icon becomes solid, count increases).
       - If the user has already reacted to the same reaction, it is removed (icon becomes hollow, count decreases).
       - If the user selects a different reaction, the previous reaction is deselected, and the new reaction is applied.

4. **Improved UI**
   - Reaction icons now dynamically reflect the logged-in user's state with seamless integration of reaction counts.

---

#### **Future Enhancements**
- Implement animations for smoother transitions when toggling reactions.
- Extend the functionality to allow reactions on blog post comments.

---

### Screenshots


Blog Post Reaction
![image](https://github.com/user-attachments/assets/4f270d13-e2d3-4e16-857c-260e725d210c)

Reactions Saved in Database
![image](https://github.com/user-attachments/assets/407e07d0-376f-44e3-9e4c-08efacb73d07)

Closes #249 