### PR TITLE
bugfix: #304 Fixed integration tests failing due to foreign key constraints on table "projects"

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/User.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/User.java
@@ -62,6 +62,9 @@ public class User extends AbstractEntity implements UserDetails {
     @JoinColumn(name = "profileId")
     private Profile profile;
 
+    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Project> projects;
+
     @Setter
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private VerificationCode verificationCode;

--- a/quolance-api/src/test/java/com/quolance/quolance_api/integration/AuthControllerIntegrationTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/integration/AuthControllerIntegrationTest.java
@@ -5,7 +5,6 @@ import com.quolance.quolance_api.dtos.LoginRequestDto;
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.entities.enums.Role;
 import com.quolance.quolance_api.helpers.EntityCreationHelper;
-import com.quolance.quolance_api.repositories.ProjectRepository;
 import com.quolance.quolance_api.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,12 +41,8 @@ class AuthControllerIntegrationTest extends AbstractTestcontainers {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private ProjectRepository projectRepository;
-
     @BeforeEach
     void setUp() {
-        projectRepository.deleteAll();
         userRepository.deleteAll();
         client = userRepository.save(EntityCreationHelper.createClient());
         freelancer = userRepository.save(EntityCreationHelper.createFreelancer(1));

--- a/quolance-api/src/test/java/com/quolance/quolance_api/integration/BlogCommentControllerIntegrationTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/integration/BlogCommentControllerIntegrationTest.java
@@ -11,7 +11,6 @@ import com.quolance.quolance_api.repositories.BlogCommentRepository;
 import com.quolance.quolance_api.repositories.BlogPostRepository;
 import com.quolance.quolance_api.repositories.ProjectRepository;
 import com.quolance.quolance_api.repositories.UserRepository;
-import com.quolance.quolance_api.services.entity_services.BlogCommentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,10 +41,6 @@ class BlogCommentControllerIntegrationTest extends AbstractTestcontainers {
 
     @Autowired
     private BlogCommentRepository blogCommentRepository;
-
-    @Autowired
-    private BlogCommentService blogCommentService;
-
 
     @Autowired
     private UserRepository userRepository;

--- a/quolance-api/src/test/java/com/quolance/quolance_api/integration/UsersControllerIntegrationTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/integration/UsersControllerIntegrationTest.java
@@ -5,7 +5,6 @@ import com.quolance.quolance_api.dtos.*;
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.entities.enums.Role;
 import com.quolance.quolance_api.helpers.EntityCreationHelper;
-import com.quolance.quolance_api.repositories.ProjectRepository;
 import com.quolance.quolance_api.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,12 +36,9 @@ class UsersControllerIntegrationTest extends AbstractTestcontainers {
 
     @Autowired
     private UserRepository userRepository;
-    @Autowired
-    private ProjectRepository projectRepository;
 
     @BeforeEach
     void setUp() {
-        projectRepository.deleteAll();
         userRepository.deleteAll();
     }
 


### PR DESCRIPTION
Added a list of projects field in the user class with a cascade declaration to fix failing integration tests. 

Integration tests were failing because of a foreign key constraint on the table project. Deleting users, without deleting the project repository first was causing problems, as seen in the image:
![image](https://github.com/user-attachments/assets/36723a4b-76ce-42f8-8f00-ae3e22579e01)

Closes #304 