### PR TITLE
feat: #334 Add BE for Profile Completion Progress Bar

### DIFF
--- a/QuolanceAPI.postman_collection.json
+++ b/QuolanceAPI.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-
-		"_postman_id": "4a19faba-6178-4e26-b2ec-68964783e25c",
+		"_postman_id": "3ff7c61a-aaf9-45fb-8a03-6c40f65e7f86",
 		"name": "QuolanceAPI",
 		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "32756588"
+		"_exporter_id": "26432903"
 	},
 	"item": [
 		{
@@ -365,7 +364,6 @@
 						"method": "GET",
 						"header": [],
 						"url": "http://localhost:8081/api/client/projects/1/applications/all"
-
 					},
 					"response": []
 				},
@@ -460,6 +458,15 @@
 						"method": "GET",
 						"header": [],
 						"url": "http://localhost:8081/api/freelancer/projects/2"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Profile Completion",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": "http://localhost:8081/api/freelancer/profile/completion"
 					},
 					"response": []
 				},
@@ -822,7 +829,6 @@
 								"method": "GET",
 								"header": [],
 								"url": ""
-
 							},
 							"response": []
 						},
@@ -925,12 +931,8 @@
 							"name": "Remove reaction",
 							"request": {
 								"method": "DELETE",
-
 								"header": [],
 								"url": ""
-
-								"header": []
-
 							},
 							"response": []
 						}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FreelancerController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FreelancerController.java
@@ -4,9 +4,12 @@ import com.quolance.quolance_api.dtos.application.ApplicationCreateDto;
 import com.quolance.quolance_api.dtos.application.ApplicationDto;
 import com.quolance.quolance_api.dtos.paging.PageResponseDto;
 import com.quolance.quolance_api.dtos.paging.PageableRequestDto;
+import com.quolance.quolance_api.dtos.profile.FreelancerProfileDto;
+import com.quolance.quolance_api.dtos.profile.ProfileCompletionCalculator;
 import com.quolance.quolance_api.dtos.profile.UpdateFreelancerProfileDto;
 import com.quolance.quolance_api.dtos.project.ProjectFilterDto;
 import com.quolance.quolance_api.dtos.project.ProjectPublicDto;
+import com.quolance.quolance_api.entities.Profile;
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.services.business_workflow.ApplicationProcessWorkflow;
 import com.quolance.quolance_api.services.business_workflow.FreelancerWorkflowService;
@@ -136,6 +139,18 @@ public class FreelancerController {
         freelancerWorkflowService.uploadProfilePicture(photo, freelancer);
         log.info("Freelancer with ID {} successfully uploaded profile picture", freelancer.getId());
         return ResponseEntity.ok("Profile picture uploaded successfully");
+    }
+
+    @GetMapping("/profile/completion")
+    @Operation(
+            summary = "Get freelancer profile completion",
+            description = "Get the completion percentage of the authenticated freelancer's profile"
+    )
+    public ResponseEntity<Integer> getProfileCompletion() {
+        User freelancer = SecurityUtil.getAuthenticatedUser();
+        ProfileCompletionCalculator profileCompletionCalculator = new ProfileCompletionCalculator();
+        int completionPercentage = profileCompletionCalculator.calculateCompletion(freelancerWorkflowService.getFreelancerProfile(freelancer.getUsername()));
+        return ResponseEntity.ok(completionPercentage);
     }
 
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/profile/ProfileCompletionCalculator.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/profile/ProfileCompletionCalculator.java
@@ -1,0 +1,53 @@
+package com.quolance.quolance_api.dtos.profile;
+
+import com.quolance.quolance_api.entities.enums.ProfileField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfileCompletionCalculator {
+
+    public int calculateCompletion(FreelancerProfileDto profile) {
+        int totalWeight = 0;
+        int completedWeight = 0;
+
+        for (ProfileField field : ProfileField.values()) {
+            totalWeight += field.getWeight();
+            if (isFieldCompleted(profile, field)) {
+                completedWeight += field.getWeight();
+            }
+        }
+
+        return (completedWeight * 100) / totalWeight;
+    }
+
+    private boolean isFieldCompleted(FreelancerProfileDto profile, ProfileField field) {
+        switch (field) {
+            case FIRST_NAME:
+                return profile.getFirstName() != null && !profile.getFirstName().isEmpty();
+            case LAST_NAME:
+                return profile.getLastName() != null && !profile.getLastName().isEmpty();
+            case USERNAME:
+                return profile.getUsername() != null && !profile.getUsername().isEmpty();
+            case PROFILE_IMAGE:
+                return profile.getProfileImageUrl() != null && !profile.getProfileImageUrl().isEmpty();
+            case BIO:
+                return profile.getBio() != null && !profile.getBio().isEmpty();
+            case CONTACT_EMAIL:
+                return profile.getContactEmail() != null && !profile.getContactEmail().isEmpty();
+            case CITY:
+                return profile.getCity() != null && !profile.getCity().isEmpty();
+            case STATE:
+                return profile.getState() != null && !profile.getState().isEmpty();
+            case EXPERIENCE_LEVEL:
+                return profile.getExperienceLevel() != null;
+            case SOCIAL_MEDIA_LINKS:
+                return profile.getSocialMediaLinks() != null && !profile.getSocialMediaLinks().isEmpty();
+            case SKILLS:
+                return profile.getSkills() != null && !profile.getSkills().isEmpty();
+            case AVAILABILITY:
+                return profile.getAvailability() != null;
+            default:
+                return false;
+        }
+    }
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/enums/ProfileField.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/enums/ProfileField.java
@@ -1,0 +1,27 @@
+package com.quolance.quolance_api.entities.enums;
+
+public enum ProfileField {
+    FIRST_NAME(10),
+    LAST_NAME(10),
+    USERNAME(10),
+    PROFILE_IMAGE(10),
+    BIO(10),
+    CONTACT_EMAIL(10),
+    CITY(10),
+    STATE(10),
+    EXPERIENCE_LEVEL(10),
+    SOCIAL_MEDIA_LINKS(10),
+    SKILLS(10),
+    AVAILABILITY(10);
+
+    private final int weight;
+
+    ProfileField(int weight) {
+        this.weight = weight;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+}
+


### PR DESCRIPTION
## Overview  
This PR adds the backend that calculates the percentage of profile completion for a Freelancers  

## Changes  
- Added `ProfileField` enum and added criteria for percentage
- Added calculator `ProfileCompletionCalculator` to calculate percentatge
- Added corresponding endpoint `/profile/completion` in `FreelancerController`

## Output
- The endpoint outputs an Integer value corresponding to percentage

## Criteria:
![image](https://github.com/user-attachments/assets/3cd47048-ecf0-457e-ae19-1aebaadd6440)


