### PR TITLE
bugfix: #288 Fixed backend bug where users could update or delete comments that are not theirs

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/blog/BlogCommentController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/blog/BlogCommentController.java
@@ -37,14 +37,16 @@ public class BlogCommentController {
     @PutMapping("/{id}")
     @Operation(summary = "Update a blog comment")
     public ResponseEntity<BlogCommentDto> updateBlogComment(@PathVariable Long id, @RequestBody BlogCommentDto request) {
-        BlogCommentDto response = blogCommentService.updateBlogComment(id, request);
+        User author = SecurityUtil.getAuthenticatedUser();
+        BlogCommentDto response = blogCommentService.updateBlogComment(id, request, author);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete a blog comment")
     public ResponseEntity<String> deleteBlogComment(@PathVariable Long id) {
-        blogCommentService.deleteBlogComment(id);
+        User author = SecurityUtil.getAuthenticatedUser();
+        blogCommentService.deleteBlogComment(id, author);
         return ResponseEntity.ok("The comment was successfully deleted");
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/blog/BlogCommentService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/blog/BlogCommentService.java
@@ -10,9 +10,9 @@ public interface BlogCommentService {
 
     BlogCommentDto createBlogComment(Long blogPostId, User author, BlogCommentDto blogCommentDto);
 
-    BlogCommentDto updateBlogComment(Long commentId, BlogCommentDto blogCommentDto);
+    BlogCommentDto updateBlogComment(Long commentId, BlogCommentDto blogCommentDto, User author);
 
-    void deleteBlogComment(Long commentId);
+    void deleteBlogComment(Long commentId, User author);
 
     List<BlogCommentDto> getCommentsByBlogPostId(Long blogPostId);
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogCommentServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogCommentServiceImpl.java
@@ -39,8 +39,12 @@ public class BlogCommentServiceImpl implements BlogCommentService {
     }
 
     @Override
-    public BlogCommentDto updateBlogComment(Long commentId, BlogCommentDto blogCommentDto) {
+    public BlogCommentDto updateBlogComment(Long commentId, BlogCommentDto blogCommentDto, User author) {
         BlogComment blogComment = getBlogCommentEntity(commentId);
+
+        if (!isAuthorOfPost(blogComment, author)) {
+            throw new ApiException("You cannot update a comment that does not belong to you.");
+        }
 
         blogComment.setContent(blogCommentDto.getContent());
         BlogComment updatedComment = blogCommentRepository.save(blogComment);
@@ -49,8 +53,12 @@ public class BlogCommentServiceImpl implements BlogCommentService {
     }
 
     @Override
-    public void deleteBlogComment(Long commentId) {
+    public void deleteBlogComment(Long commentId, User author) {
         BlogComment blogComment = getBlogCommentEntity(commentId);
+
+        if (!isAuthorOfPost(blogComment, author)) {
+            throw new ApiException("You cannot delete a comment that does not belong to you.");
+        }
 
         blogCommentRepository.delete(blogComment);
     }
@@ -64,6 +72,10 @@ public class BlogCommentServiceImpl implements BlogCommentService {
         return comments.stream()
                 .map(BlogCommentDto::fromEntity)
                 .toList();
+    }
+
+    private boolean isAuthorOfPost(BlogComment blogComment, User author) {
+        return blogComment.getUser().getId().equals(author.getId());
     }
 
     public BlogComment getBlogCommentEntity(Long commentId) {


### PR DESCRIPTION
# Fixed backend bug where users could update or delete comments that wasn't theirs

## Deleting other users' comment
![image](https://github.com/user-attachments/assets/ae6d1849-673b-4f4c-94fd-5555e79a9e93)

## Updating other users' comment
![image](https://github.com/user-attachments/assets/dc97fcf0-ce25-432b-aef3-9758e5fcf317)

Closes #288 