### PR TITLE
bugfix: #379 Added temporary fix for users cant verify account in production

### DIFF
--- a/infrastructure/docker-compose.yaml
+++ b/infrastructure/docker-compose.yaml
@@ -3,8 +3,8 @@ services:
     image: postgres:15
     container_name: quolance-postgres-db-container
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
       POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "${POSTGRES_HOST_PORT}:${POSTGRES_CONTAINER_PORT}"

--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/AdminInitializer.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/AdminInitializer.java
@@ -8,12 +8,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("local")
+//@Profile("local") //TODO: Bring back this line when a permanent solution is found to admin creation
 @RequiredArgsConstructor
 public class AdminInitializer implements CommandLineRunner {
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
@@ -54,6 +54,7 @@ public class UserServiceImpl implements UserService {
         log.info("Successfully created new user with ID: {}", user.getId());
 
         sendVerificationEmail(user);
+        user.setVerified(true); //TODO: Remove this line when email verification is completed
         log.debug("Verification email process initiated for user ID: {}", user.getId());
 
         return new UserResponseDto(user);
@@ -71,6 +72,7 @@ public class UserServiceImpl implements UserService {
 
         User user = new User(request);
         user = userRepository.save(user);
+        user.setVerified(true); // TODO: Remove this line when email verification is completed
         log.info("Successfully created new admin user with ID: {}", user.getId());
 
         return new UserResponseDto(user);

--- a/quolance-api/src/test/resources/application-test.yml
+++ b/quolance-api/src/test/resources/application-test.yml
@@ -4,6 +4,9 @@ app:
   allowed-origins: "http://localhost"
   login-page-url: "${app.base-url}/auth/login"
   login-success-url: "${app.base-url}/auth/login-success"
+  admin:
+    email: ${ADMIN_EMAIL}
+    password: ${ADMIN_PASSWORD}
 
 spring:
   application:
@@ -11,6 +14,8 @@ spring:
 
   datasource:
     url: "${LOCAL_DATASOURCE_URL}"
+    username: "postgres"
+    password: "postgres"
     driver-class-name: org.postgresql.Driver
 
   mail:


### PR DESCRIPTION
# In this PR:
- Temporarily removed Profile setting on the AdminInitializer to have an admin generated in production.
- Temporarily set user verification to true without validating email.

Closes #379 