### PR TITLE
feat: #395 Added toggle for project evaluation by AI model

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/FeatureToggleConfig.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/FeatureToggleConfig.java
@@ -1,0 +1,17 @@
+package com.quolance.quolance_api.configs;
+
+import com.quolance.quolance_api.util.FeatureToggle;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource("classpath:toggles.properties")
+public class FeatureToggleConfig {
+    @Bean
+    @ConfigurationProperties(prefix = "feature.toggles")
+    public FeatureToggle featureToggle() {
+        return new FeatureToggle();
+    }
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/ClientController.java
@@ -44,8 +44,7 @@ public class ClientController {
         User client = SecurityUtil.getAuthenticatedUser();
         log.info("Client {} attempting to create project", client.getId());
         ProjectEvaluationResult result = clientWorkflowService.createProject(projectCreateDto, client);
-        log.info("Project creation completed for client {}. Moderation status: approved={}, review={}",
-                client.getId(), result.isApproved(), result.isRequiresManualReview());
+        log.info("Client {} successfully created project.", client.getId());
         return ResponseEntity.ok(result);
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/project/ProjectEvaluationResult.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/project/ProjectEvaluationResult.java
@@ -12,9 +12,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProjectEvaluationResult {
-    private boolean approved;
+    private boolean approved = false;
     private double confidenceScore;
     private String reason;
     private List<String> flags;
-    private boolean requiresManualReview;
+    private boolean requiresManualReview = true;
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
@@ -276,6 +276,7 @@ public class ProjectServiceImpl implements ProjectService {
                 && result.getConfidenceScore() >= 0.9) {
             updateProjectStatus(project, ProjectStatus.REJECTED);
         }
+        log.info("Moderation status for project with ID {}: approved={}, review={}", project.getId(), result.isApproved(), result.isRequiresManualReview());
         return result;
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/util/FeatureToggle.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/util/FeatureToggle.java
@@ -1,0 +1,20 @@
+package com.quolance.quolance_api.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FeatureToggle {
+    private Map<String, Boolean> toggles = new HashMap<>();
+
+    public Map<String, Boolean> getToggles() {
+        return toggles;
+    }
+
+    public void setToggles(Map<String, Boolean> toggles) {
+        this.toggles = toggles;
+    }
+
+    public boolean isEnabled(String featureName) {
+        return toggles.getOrDefault(featureName, false);
+    }
+}

--- a/quolance-api/src/main/resources/toggles.properties
+++ b/quolance-api/src/main/resources/toggles.properties
@@ -1,0 +1,1 @@
+feature.toggles.toggles.useAiProjectEvaluation=true

--- a/quolance-api/src/test/java/com/quolance/quolance_api/integration/tests/ClientControllerIntegrationTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/integration/tests/ClientControllerIntegrationTest.java
@@ -13,11 +13,14 @@ import com.quolance.quolance_api.integration.BaseIntegrationTest;
 import com.quolance.quolance_api.repositories.ApplicationRepository;
 import com.quolance.quolance_api.repositories.ProjectRepository;
 import com.quolance.quolance_api.repositories.UserRepository;
+import com.quolance.quolance_api.util.FeatureToggle;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -29,7 +32,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ActiveProfiles("test")
@@ -46,6 +48,9 @@ class ClientControllerIntegrationTest extends BaseIntegrationTest {
 
     private User client;
 
+    @MockBean
+    private FeatureToggle featureToggle;
+
     @BeforeEach
     void setUp() throws Exception {
         projectRepository.deleteAll();
@@ -55,82 +60,83 @@ class ClientControllerIntegrationTest extends BaseIntegrationTest {
         session = sessionCreationHelper.getSession("client@test.com", "Password123!");
     }
 
+    @Test
+    void createProjectWhenFeatureToggleDisabledShouldSkipAIApproval() throws Exception {
+        // Arrange
+        Mockito.when(featureToggle.isEnabled("useAiProjectEvaluation")).thenReturn(false);
 
-//    @Test
-//    void createProjectValidIsOk() throws Exception {
-//        //Arrange
-//        ProjectCreateDto projectDto = ProjectCreateDto.builder()
-//                .title("title")
-//                .description("description")
-//                .category(ProjectCategory.APP_DEVELOPMENT)
-//                .priceRange(PriceRange.LESS_500)
-//                .experienceLevel(FreelancerExperienceLevel.JUNIOR)
-//                .expectedDeliveryTime(ExpectedDeliveryTime.FLEXIBLE)
-//                .build();
-//
-//        //Act
-//        String response = mockMvc.perform(post("/api/client/create-project").session(session).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(projectDto)))
-//                .andExpect(status().isOk())
-//                .andReturn()
-//                .getResponse().getContentAsString();
-//
-//        //Assert
-//        Project project = projectRepository.findAll().getFirst();
-//        assertThat(response).isEqualTo("Project created successfully");
-//        assertThat(projectRepository.findAll()).hasSize(1);
-//        assertThat(project.getTitle()).isEqualTo("title");
-//        assertThat(project.getDescription()).isEqualTo("description");
-//        assertThat(project.getCategory()).isEqualTo(ProjectCategory.APP_DEVELOPMENT);
-//        assertThat(project.getPriceRange()).isEqualTo(PriceRange.LESS_500);
-//        assertThat(project.getExperienceLevel()).isEqualTo(FreelancerExperienceLevel.JUNIOR);
-//        assertThat(project.getExpectedDeliveryTime()).isEqualTo(ExpectedDeliveryTime.FLEXIBLE);
-//    }
+        ProjectCreateDto projectDto = ProjectCreateDto.builder()
+                .title("title")
+                .description("description")
+                .category(ProjectCategory.APP_DEVELOPMENT)
+                .priceRange(PriceRange.LESS_500)
+                .experienceLevel(FreelancerExperienceLevel.JUNIOR)
+                .expectedDeliveryTime(ExpectedDeliveryTime.FLEXIBLE)
+                .build();
 
-//    @Test
-//    void createProjectWithExpirationDateSetsExpirationDate() throws Exception {
-//        //Arrange
-//        ProjectCreateDto projectDto = ProjectCreateDto.builder()
-//                .title("title")
-//                .description("description")
-//                .category(ProjectCategory.APP_DEVELOPMENT)
-//                .priceRange(PriceRange.LESS_500)
-//                .experienceLevel(FreelancerExperienceLevel.JUNIOR)
-//                .expectedDeliveryTime(ExpectedDeliveryTime.FLEXIBLE)
-//                .expirationDate(LocalDate.now().plusDays(10))
-//                .build();
-//        //Act
-//        mockMvc.perform(post("/api/client/create-project").session(session)
-//                        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(projectDto)))
-//                .andExpect(status().isOk())
-//                .andExpect(content().string("Project created successfully"));
-//        //Assert
-//        Project project = projectRepository.findAll().getFirst();
-//        assertThat(project.getExpirationDate()).isEqualTo(LocalDate.now().plusDays(10));
-//    }
+        // Act
+        String response = mockMvc.perform(post("/api/client/create-project")
+                        .session(session)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(projectDto)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse().getContentAsString();
 
-//    @Test
-//    void createProjectWithNoExpirationDateSetsExpirationDateTo7DaysFromNow() throws Exception {
-//        //Arrange
-//        ProjectCreateDto projectDto = ProjectCreateDto.builder()
-//                .title("title")
-//                .description("description")
-//                .category(ProjectCategory.APP_DEVELOPMENT)
-//                .priceRange(PriceRange.LESS_500)
-//                .experienceLevel(FreelancerExperienceLevel.JUNIOR)
-//                .expectedDeliveryTime(ExpectedDeliveryTime.FLEXIBLE)
-//                .build();
-//
-//        //Act
-//        String response = mockMvc.perform(post("/api/client/create-project").session(session).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(projectDto)))
-//                .andExpect(status().isOk())
-//                .andReturn()
-//                .getResponse().getContentAsString();
-//
-//        //Assert
-//        Project project = projectRepository.findAll().getFirst();
-//        assertThat(response).isEqualTo("Project created successfully");
-//        assertThat(project.getExpirationDate()).isEqualTo(LocalDate.now().plusDays(7));
-//    }
+        // Assert
+        Map<String, Object> jsonResponse = objectMapper.readValue(response, Map.class);
+        Project project = projectRepository.findAll().getFirst();
+        assertThat(jsonResponse).containsEntry("reason", null); // always null when AI is disabled
+        assertThat(projectRepository.findAll()).hasSize(1);
+        assertThat(project.getTitle()).isEqualTo("title");
+    }
+
+
+    @Test
+    void createProjectWithExpirationDateSetsExpirationDate() throws Exception {
+        //Arrange
+        Mockito.when(featureToggle.isEnabled("useAiProjectEvaluation")).thenReturn(false);
+
+        ProjectCreateDto projectDto = ProjectCreateDto.builder()
+                .title("title")
+                .description("description")
+                .category(ProjectCategory.APP_DEVELOPMENT)
+                .priceRange(PriceRange.LESS_500)
+                .experienceLevel(FreelancerExperienceLevel.JUNIOR)
+                .expectedDeliveryTime(ExpectedDeliveryTime.FLEXIBLE)
+                .expirationDate(LocalDate.now().plusDays(10))
+                .build();
+        //Act
+        mockMvc.perform(post("/api/client/create-project").session(session)
+                        .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(projectDto)))
+                .andExpect(status().isOk());
+        //Assert
+        Project project = projectRepository.findAll().getFirst();
+        assertThat(project.getExpirationDate()).isEqualTo(LocalDate.now().plusDays(10));
+    }
+
+    @Test
+    void createProjectWithNoExpirationDateSetsExpirationDateTo7DaysFromNow() throws Exception {
+        //Arrange
+        Mockito.when(featureToggle.isEnabled("useAiProjectEvaluation")).thenReturn(false);
+
+        ProjectCreateDto projectDto = ProjectCreateDto.builder()
+                .title("title")
+                .description("description")
+                .category(ProjectCategory.APP_DEVELOPMENT)
+                .priceRange(PriceRange.LESS_500)
+                .experienceLevel(FreelancerExperienceLevel.JUNIOR)
+                .expectedDeliveryTime(ExpectedDeliveryTime.FLEXIBLE)
+                .build();
+
+        //Act
+        mockMvc.perform(post("/api/client/create-project").session(session).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(projectDto)))
+                .andExpect(status().isOk());
+
+        //Assert
+        Project project = projectRepository.findAll().getFirst();
+        assertThat(project.getExpirationDate()).isEqualTo(LocalDate.now().plusDays(7));
+    }
 
     @Test
     void getProjectByIdWhenNoneExistReturnsNotFound() throws Exception {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/ClientWorkflowServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/ClientWorkflowServiceUnitTest.java
@@ -15,15 +15,13 @@ import com.quolance.quolance_api.services.business_workflow.impl.ClientWorkflowS
 import com.quolance.quolance_api.services.entity_services.ApplicationService;
 import com.quolance.quolance_api.services.entity_services.ProjectService;
 import com.quolance.quolance_api.services.entity_services.UserService;
+import com.quolance.quolance_api.util.FeatureToggle;
 import com.quolance.quolance_api.util.exceptions.ApiException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -55,6 +53,8 @@ class ClientWorkflowServiceUnitTest {
 
     @InjectMocks
     private ClientWorkflowServiceImpl clientWorkflowService;
+
+    private FeatureToggle featureToggle = mock(FeatureToggle.class);
 
     @Captor
     private ArgumentCaptor<Project> projectCaptor;
@@ -124,6 +124,8 @@ class ClientWorkflowServiceUnitTest {
 
     @Test
     void createProject_WithExpirationDate_Success() {
+        Mockito.when(featureToggle.isEnabled("useAiProjectEvaluation")).thenReturn(false);
+
         clientWorkflowService.createProject(mockProjectCreateDto, mockClient);
 
         verify(projectService).saveProject(projectCaptor.capture());
@@ -142,6 +144,8 @@ class ClientWorkflowServiceUnitTest {
 
     @Test
     void createProject_WithoutExpirationDate_SetsDefaultDate() {
+        Mockito.when(featureToggle.isEnabled("useAiProjectEvaluation")).thenReturn(false);
+
         mockProjectCreateDto.setExpirationDate(null);
 
         clientWorkflowService.createProject(mockProjectCreateDto, mockClient);


### PR DESCRIPTION
# In this PR:
- Added a toggle `useAiProjectEvaluation` to activate and deactivate the AI feature to automatically approve/reject projects.
- To enable the AI feature, set the value `feature.toggles.toggles.useAiProjectEvaluation=true` in `toggles.properties`
- For now, we are returning a `ProjectEvaluationResult` object, both when the toggle is on and off. However, when it is off and it behaves as it did previously (ie: when the project was by default to be approved by an admin), we do not need it. Might need to delete this entity, especially if it is not needed in the UI.

Closes #395 