### PR TITLE
feat: #401 User can verify email by entering a code received by email

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/ApplicationProperties.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/ApplicationProperties.java
@@ -19,4 +19,5 @@ public class ApplicationProperties {
     private String loginSuccessUrl;
     private String adminUserEmail;
     private String adminUserPassword;
+    private String verifyEmailUrl;
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/SecurityConfiguration.java
@@ -70,7 +70,7 @@ public class SecurityConfiguration {
                             .requestMatchers(antMatcher(HttpMethod.GET, "/ws/**")).permitAll() // Allow WebSocket handshake
                             .requestMatchers(WHITE_LIST_URL).permitAll()
                             .requestMatchers(antMatcher(HttpMethod.POST, "/api/users")).permitAll()
-                            .requestMatchers(antMatcher(HttpMethod.GET, "/api/users/verify-email")).permitAll()
+                            .requestMatchers(antMatcher(HttpMethod.POST, "/api/users/verify-email")).permitAll()
                             .requestMatchers(antMatcher(HttpMethod.POST, "/api/users/forgot-password")).permitAll()
                             .requestMatchers(antMatcher(HttpMethod.PATCH, "/api/users/reset-password")).permitAll()
                             .requestMatchers(antMatcher(HttpMethod.POST, "/api/users/admin")).hasRole("ADMIN")

--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/UsersController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/UsersController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.view.RedirectView;
 
 @Slf4j
 @RestController
@@ -54,13 +53,13 @@ public class UsersController {
         return ResponseEntity.ok(user);
     }
 
-    @GetMapping("/verify-email")
+    @PostMapping("/verify-email")
     @Operation(
             summary = "Verify the email of the user",
             description = "Verify the email of the user by passing the token")
-    public RedirectView verifyEmail(@RequestParam String token) {
-        userService.verifyEmail(token);
-        return new RedirectView(applicationProperties.getLoginPageUrl());
+    public ResponseEntity<String> verifyEmail(@RequestBody VerifyEmailDto verificationDto) {
+        String verificationResponse = userService.verifyEmail(verificationDto);
+        return ResponseEntity.ok(verificationResponse);
     }
 
     @PostMapping("/forgot-password")

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/users/VerifyEmailDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/users/VerifyEmailDto.java
@@ -1,0 +1,16 @@
+package com.quolance.quolance_api.dtos.users;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+public class VerifyEmailDto {
+    @NotNull
+    private String email;
+    @NotNull
+    private String verificationCode;
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/jobs/handlers/SendWelcomeEmailJobHandler.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/jobs/handlers/SendWelcomeEmailJobHandler.java
@@ -56,13 +56,13 @@ public class SendWelcomeEmailJobHandler implements JobRequestHandler<SendWelcome
     }
 
     private void sendWelcomeEmail(User user, VerificationCode code) throws MessagingException {
-        String verificationLink = applicationProperties.getBaseUrl() + "/api/users/verify-email?token=" + code.getCode();
         Context thymeleafContext = new Context();
         thymeleafContext.setVariable("user", user);
         thymeleafContext.setVariable("verificationLink", verificationLink);
         thymeleafContext.setVariable("applicationName", applicationProperties.getApplicationName());
+        thymeleafContext.setVariable("verificationCode", code.getCode());
         String htmlBody = templateEngine.process("welcome-email", thymeleafContext);
-        emailService.sendHtmlMessage(List.of(user.getEmail()), "Welcome to our platform", htmlBody);
+        emailService.sendHtmlMessage(List.of(user.getEmail()), "Welcome to Quolance", htmlBody);
         code.setEmailSent(true);
         verificationCodeService.updateVerificationCodeStatus(code);
     }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/jobs/handlers/SendWelcomeEmailJobHandler.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/jobs/handlers/SendWelcomeEmailJobHandler.java
@@ -58,9 +58,8 @@ public class SendWelcomeEmailJobHandler implements JobRequestHandler<SendWelcome
     private void sendWelcomeEmail(User user, VerificationCode code) throws MessagingException {
         Context thymeleafContext = new Context();
         thymeleafContext.setVariable("user", user);
-        thymeleafContext.setVariable("verificationLink", verificationLink);
-        thymeleafContext.setVariable("applicationName", applicationProperties.getApplicationName());
         thymeleafContext.setVariable("verificationCode", code.getCode());
+        thymeleafContext.setVariable("verificationLink", applicationProperties.getVerifyEmailUrl());
         String htmlBody = templateEngine.process("welcome-email", thymeleafContext);
         emailService.sendHtmlMessage(List.of(user.getEmail()), "Welcome to Quolance", htmlBody);
         code.setEmailSent(true);

--- a/quolance-api/src/main/java/com/quolance/quolance_api/repositories/VerificationCodeRepository.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/repositories/VerificationCodeRepository.java
@@ -4,7 +4,6 @@ import com.quolance.quolance_api.entities.VerificationCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -12,5 +11,5 @@ public interface VerificationCodeRepository extends JpaRepository<VerificationCo
 
     VerificationCode save(VerificationCode verificationCode);
 
-    Optional<VerificationCode> findByCode(String code);
+    VerificationCode findByCode(String code);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/auth/VerificationCodeService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/auth/VerificationCodeService.java
@@ -2,13 +2,11 @@ package com.quolance.quolance_api.services.auth;
 
 import com.quolance.quolance_api.entities.VerificationCode;
 
-import java.util.Optional;
-
 public interface VerificationCodeService {
 
     VerificationCode createVerificationCode(VerificationCode verificationCode);
 
-    Optional<VerificationCode> findByCode(String code);
+    VerificationCode findByCode(String code);
 
     boolean updateVerificationCodeStatus(VerificationCode verificationCode);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/auth/impl/VerificationCodeServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/auth/impl/VerificationCodeServiceImpl.java
@@ -6,8 +6,6 @@ import com.quolance.quolance_api.services.auth.VerificationCodeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class VerificationCodeServiceImpl implements VerificationCodeService {
@@ -20,7 +18,7 @@ public class VerificationCodeServiceImpl implements VerificationCodeService {
     }
 
     @Override
-    public Optional<VerificationCode> findByCode(String code) {
+    public VerificationCode findByCode(String code) {
         return verificationCodeRepository.findByCode(code);
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/UserService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/UserService.java
@@ -18,7 +18,7 @@ public interface UserService {
 
     Optional<User> findByUsername(String username);
 
-    void verifyEmail(String code);
+    String verifyEmail(VerifyEmailDto verifyEmailDto);
 
     void forgotPassword(String email);
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
@@ -9,6 +9,7 @@ import com.quolance.quolance_api.jobs.SendWelcomeEmailJob;
 import com.quolance.quolance_api.repositories.PasswordResetTokenRepository;
 import com.quolance.quolance_api.repositories.UserRepository;
 import com.quolance.quolance_api.repositories.VerificationCodeRepository;
+import com.quolance.quolance_api.services.auth.VerificationCodeService;
 import com.quolance.quolance_api.services.entity_services.UserService;
 import com.quolance.quolance_api.util.exceptions.ApiException;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,6 +34,7 @@ public class UserServiceImpl implements UserService {
     private final VerificationCodeRepository verificationCodeRepository;
     private final PasswordResetTokenRepository passwordResetTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final VerificationCodeService verificationCodeService;
 
     @Override
     @Transactional
@@ -118,6 +120,17 @@ public class UserServiceImpl implements UserService {
         return user;
     }
 
+    private User findByEmail(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> {
+            log.warn("No user found with email: {}", email);
+            return ApiException.builder()
+                    .status(HttpServletResponse.SC_NOT_FOUND)
+                    .message("User not found")
+                    .build();
+        });
+        return user;
+    }
+
     private void sendVerificationEmail(User user) {
         log.debug("Creating verification code for user ID: {}", user.getId());
         VerificationCode verificationCode = new VerificationCode(user);
@@ -137,22 +150,38 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void verifyEmail(String code) {
-        log.debug("Attempting to verify email with code: {}", code);
-        VerificationCode verificationCode = verificationCodeRepository.findByCode(code)
-                .orElseThrow(() -> {
-                    log.warn("Email verification failed - invalid code: {}", code);
-                    return ApiException.builder()
-                            .status(HttpServletResponse.SC_BAD_REQUEST)
-                            .message("Invalid token")
-                            .build();
-                });
+    public String verifyEmail(VerifyEmailDto verifyEmailDto) {
+        log.debug("Attempting to verify email: {}", verifyEmailDto.getEmail());
+        VerificationCode verificationCode = verificationCodeService.findByCode(verifyEmailDto.getVerificationCode());
+        User user = findByEmail(verifyEmailDto.getEmail());
 
-        User user = verificationCode.getUser();
+        if (user.isVerified()) {
+            log.warn("User {} - already verified.", verifyEmailDto.getEmail());
+            throw ApiException.builder()
+                    .status(HttpServletResponse.SC_BAD_REQUEST)
+                    .message("Email already verified")
+                    .build();
+        }
+        if (verificationCode == null) {
+            log.warn("Email verification failed for {} - invalid code.", verifyEmailDto.getEmail());
+            throw ApiException.builder()
+                    .status(HttpServletResponse.SC_NOT_FOUND)
+                    .message("Invalid code")
+                    .build();
+        }
+        if (!verificationCode.getCode().equals(verifyEmailDto.getVerificationCode())) {
+            log.warn("Email verification failed for {} - invalid code: {}", verifyEmailDto.getEmail());
+            throw ApiException.builder()
+                    .status(HttpServletResponse.SC_BAD_REQUEST)
+                    .message("Invalid code")
+                    .build();
+        }
+
         user.setVerified(true);
         userRepository.save(user);
         verificationCodeRepository.delete(verificationCode);
-        log.info("Successfully verified email for user ID: {}", user.getId());
+        log.info("Successfully verified email for: {}", user.getEmail());
+        return "Email verified successfully";
     }
 
     @Override

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/UserServiceImpl.java
@@ -53,7 +53,6 @@ public class UserServiceImpl implements UserService {
         user = userRepository.save(user);
         log.info("Successfully created new user with ID: {}", user.getId());
 
-        user.setVerified(true);
         sendVerificationEmail(user);
         log.debug("Verification email process initiated for user ID: {}", user.getId());
 

--- a/quolance-api/src/main/resources/application-local.yml
+++ b/quolance-api/src/main/resources/application-local.yml
@@ -1,9 +1,11 @@
 app:
   application-name: Quolance
   base-url: "http://localhost:8080"
+  ui-url: "http://localhost:3000"
   allowed-origins: "http://localhost"
   login-page-url: "${app.base-url}/auth/login"
   login-success-url: "${app.base-url}/auth/login-success"
+  verify-email-url: "${app.ui-url}/auth/verify-email"
 
 spring:
   servlet:

--- a/quolance-api/src/main/resources/application.yml
+++ b/quolance-api/src/main/resources/application.yml
@@ -1,9 +1,11 @@
 app:
   application-name: Quolance
   base-url: "https://api.quolance.com"
+  ui-url: "https://quolance.com"
   allowed-origins: "http://localhost"
   login-page-url: "${app.base-url}/auth/login"
   login-success-url: "${app.base-url}/auth/login-success"
+  verify-email-url: "${app.ui-url}/auth/verify-email"
 
   admin:
     email: ${ADMIN_EMAIL}

--- a/quolance-api/src/main/resources/mail-templates/welcome-email.html
+++ b/quolance-api/src/main/resources/mail-templates/welcome-email.html
@@ -5,13 +5,108 @@
     <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
           name="viewport">
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
-    <title>Document</title>
+    <title>Welcome to Quolance</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        }
+
+        body {
+            background-color: #f5f5f5;
+            padding: 20px;
+        }
+
+        .email-container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            padding: 40px;
+        }
+
+        .quolance {
+            font-size: 24px;
+            font-weight: 700;
+            color: #1a1a1a;
+            margin-bottom: 30px;
+            text-decoration: none;
+        }
+
+        h1 {
+            font-size: 24px;
+            color: #1a1a1a;
+            margin-bottom: 20px;
+        }
+
+        p {
+            color: #4a4a4a;
+            font-size: 16px;
+            line-height: 1.6;
+            margin-bottom: 16px;
+        }
+
+        .verification-code {
+            background-color: #f8f9fa;
+            padding: 16px;
+            border-radius: 6px;
+            font-size: 24px;
+            font-weight: bold;
+            color: #1a1a1a;
+            text-align: center;
+            margin: 24px 0;
+            letter-spacing: 2px;
+        }
+
+        .button {
+            display: inline-block;
+            background-color: #3B6BFF;
+            color: white;
+            text-decoration: none;
+            padding: 12px 24px;
+            border-radius: 6px;
+            font-weight: 500;
+            margin: 24px 0;
+        }
+
+        .footer {
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 1px solid #eee;
+            font-size: 14px;
+            color: #666;
+        }
+    </style>
 </head>
 <body>
-<p th:text="'Hi 👋 ' + ${user.firstName} + '!'"></p>
-<p th:text="'We are happy to see you join us for great opportunities! To complete your account creation, please enter the following code on the site:'"></p>
-<p th:text="'Verification code: ' + ${verificationCode}"></p>
-<p th:text="'Do not share the code with anyone. It will expire in 10 minutes.'"></p>
-<p th:text="'If you did not request this code, please ignore this email.'"></p>
+<div class="email-container">
+    <div class="quolance">
+        Quolance
+    </div>
+
+    <h1 th:text="'Welcome to Quolance, ' + ${user.firstName} + '!'"></h1>
+
+    <p>We're excited to have you join our community of talented freelancers and contractors. To get started, please
+        verify your email address.</p>
+
+    <div class="verification-code" th:text="${verificationCode}"></div>
+
+    <p>Enter this verification code on the site to complete your account creation. This code will expire in 10
+        minutes.</p>
+
+    <a class="button" th:href="@{${verificationLink}}" target="_blank">
+        Verify Email Address
+    </a>
+
+    <p style="font-size: 14px; color: #666;">If you didn't create an account with Quolance, please ignore this
+        email.</p>
+
+    <div class="footer">
+        <p>Need help? Contact our support team at support@quolance.com</p>
+    </div>
+</div>
 </body>
 </html>

--- a/quolance-api/src/main/resources/mail-templates/welcome-email.html
+++ b/quolance-api/src/main/resources/mail-templates/welcome-email.html
@@ -8,7 +8,10 @@
     <title>Document</title>
 </head>
 <body>
-<p th:text="'Hi 👋' + ${user.firstName} + '!'"></p>
-<p th:text="'Welcome to Quolance, your account is created successfully'"></p>
+<p th:text="'Hi 👋 ' + ${user.firstName} + '!'"></p>
+<p th:text="'We are happy to see you join us for great opportunities! To complete your account creation, please enter the following code on the site:'"></p>
+<p th:text="'Verification code: ' + ${verificationCode}"></p>
+<p th:text="'Do not share the code with anyone. It will expire in 10 minutes.'"></p>
+<p th:text="'If you did not request this code, please ignore this email.'"></p>
 </body>
 </html>

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/UsersControllerUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/UsersControllerUnitTest.java
@@ -1,6 +1,5 @@
 package com.quolance.quolance_api.unit.controllers;
 
-import com.quolance.quolance_api.configs.ApplicationProperties;
 import com.quolance.quolance_api.controllers.UsersController;
 import com.quolance.quolance_api.dtos.users.*;
 import com.quolance.quolance_api.entities.User;
@@ -18,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.UUID;
 
@@ -31,9 +29,6 @@ class UsersControllerUnitTest {
 
     @Mock
     private UserService userService;
-
-    @Mock
-    private ApplicationProperties applicationProperties;
 
     @InjectMocks
     private UsersController usersController;
@@ -271,36 +266,6 @@ class UsersControllerUnitTest {
         verify(userService).createAdmin(invalidRequest);
         verifyNoMoreInteractions(userService);
         }
-    }
-
-    @Test
-    void verifyEmail_Success() {
-        String token = "valid-token";
-        String loginPageUrl = "http://example.com/login";
-        when(applicationProperties.getLoginPageUrl()).thenReturn(loginPageUrl);
-        doNothing().when(userService).verifyEmail(token);
-
-        RedirectView response = usersController.verifyEmail(token);
-
-        assertThat(response.getUrl()).isEqualTo(loginPageUrl);
-        verify(userService).verifyEmail(token);
-        verifyNoMoreInteractions(userService);
-    }
-
-    @Test
-    void verifyEmail_WithInvalidToken_ThrowsApiException() {
-        String invalidToken = "invalid-token";
-        doThrow(ApiException.builder()
-                .message("Invalid token")
-                .status(400)
-                .build())
-                .when(userService).verifyEmail(invalidToken);
-
-        assertThatThrownBy(() -> usersController.verifyEmail(invalidToken))
-                .isInstanceOf(ApiException.class)
-                .hasMessage("Invalid token");
-        verify(userService).verifyEmail(invalidToken);
-        verifyNoMoreInteractions(userService);
     }
 
     @Test

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/entity_services/UserServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/entity_services/UserServiceUnitTest.java
@@ -183,28 +183,6 @@ class UserServiceUnitTest {
     }
 
     @Test
-    void verifyEmail_Success() {
-        when(verificationCodeRepository.findByCode("test_code")).thenReturn(Optional.of(mockVerificationCode));
-
-        userService.verifyEmail("test_code");
-
-        verify(userRepository).save(userCaptor.capture());
-        User savedUser = userCaptor.getValue();
-        assertThat(savedUser.isVerified()).isTrue();
-        verify(verificationCodeRepository).delete(mockVerificationCode);
-    }
-
-    @Test
-    void verifyEmail_InvalidCode_ThrowsException() {
-        when(verificationCodeRepository.findByCode(anyString())).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> userService.verifyEmail("invalid_code"))
-                .isInstanceOf(ApiException.class)
-                .hasFieldOrPropertyWithValue("status", 400)
-                .hasMessage("Invalid token");
-    }
-
-    @Test
     void forgotPassword_Success() {
         when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(mockUser));
         when(passwordResetTokenRepository.save(any(PasswordResetToken.class))).thenReturn(mockPasswordResetToken);
@@ -294,8 +272,9 @@ class UserServiceUnitTest {
 
         Optional<User> result = userService.findById(mockUser.getId());
 
-        assertThat(result).isPresent();
-        assertThat(result).contains(mockUser);
+        assertThat(result)
+                .isPresent()
+                .contains(mockUser);
         verify(userRepository).findById(mockUser.getId());
     }
 
@@ -316,8 +295,9 @@ class UserServiceUnitTest {
 
         Optional<User> result = userService.findByUsername("testuser");
 
-        assertThat(result).isPresent();
-        assertThat(result).contains(mockUser);
+        assertThat(result)
+                .isPresent()
+                .contains(mockUser);
         verify(userRepository).findByUsername("testuser");
     }
 

--- a/quolance-ui/src/app/(without-main-layout)/auth/register/components/register-form.tsx
+++ b/quolance-ui/src/app/(without-main-layout)/auth/register/components/register-form.tsx
@@ -1,24 +1,21 @@
 'use client';
 
-import { zodResolver } from '@hookform/resolvers/zod';
+import {zodResolver} from '@hookform/resolvers/zod';
 import Link from 'next/link';
 import React from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import { z } from 'zod';
+import {useForm} from 'react-hook-form';
+import {toast} from 'sonner';
+import {z} from 'zod';
 
 import httpClient from '@/lib/httpClient';
 import ErrorFeedback from '@/components/error-feedback';
 import SuccessFeedback from '@/components/success-feedback';
-import { Button } from '@/components/ui/button';
-import { HttpErrorResponse } from '@/constants/models/http/HttpErrorResponse';
-import { cn } from '@/util/utils';
-import { RegistrationUserType } from '@/app/(without-main-layout)/auth/register/page';
-import { Role } from '@/constants/models/user/UserResponse';
-import {
-  FormInput,
-  SocialAuthLogins,
-} from '@/app/(without-main-layout)/auth/shared/auth-components';
+import {Button} from '@/components/ui/button';
+import {HttpErrorResponse} from '@/constants/models/http/HttpErrorResponse';
+import {cn} from '@/util/utils';
+import {RegistrationUserType} from '@/app/(without-main-layout)/auth/register/page';
+import {Role} from '@/constants/models/user/UserResponse';
+import {FormInput, SocialAuthLogins,} from '@/app/(without-main-layout)/auth/shared/auth-components';
 
 type UserAuthFormProps = React.HTMLAttributes<HTMLDivElement> & {
   userRole: RegistrationUserType;
@@ -83,10 +80,10 @@ export function UserRegisterForm({
       <SuccessFeedback
         show={success}
         message='Account created'
-        description='Verfication email will be sent to your inbox, please click the link in the email to verify your account'
+        description='An email verification code has been sent to your inbox. Please enter the code to verify your account.'
         action={
-          <Link href='/auth/login' className='underline'>
-            Login
+            <Link href='/auth/verify-email' className='underline'>
+                Verify Email
           </Link>
         }
         data-test = "success-message"

--- a/quolance-ui/src/app/(without-main-layout)/auth/verify-email/components/verification-code.tsx
+++ b/quolance-ui/src/app/(without-main-layout)/auth/verify-email/components/verification-code.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import {zodResolver} from '@hookform/resolvers/zod';
+import Link from "next/link";
+import {useRouter} from 'next/navigation';
+import * as React from 'react';
+import {useForm} from 'react-hook-form';
+import {toast} from 'sonner';
+import * as z from 'zod';
+
+import httpClient from "@/lib/httpClient";
+
+import ErrorFeedback from '@/components/error-feedback';
+import SuccessFeedback from "@/components/success-feedback";
+import {Button} from '@/components/ui/button';
+
+import {FormInput} from '@/app/(without-main-layout)/auth/shared/auth-components';
+import {HttpErrorResponse} from '@/constants/models/http/HttpErrorResponse';
+
+const verificationFormSchema = z.object({
+    email: z.string().email('Please enter a valid email address'),
+    verificationCode: z.string().min(6, 'Verification code must be at least 6 characters'),
+});
+
+type VerificationSchema = z.infer<typeof verificationFormSchema>;
+
+export function VerificationForm({
+                                     className,
+                                     ...props
+                                 }: React.HTMLAttributes<HTMLDivElement>) {
+    const router = useRouter();
+    const [success, setSuccess] = React.useState<boolean>(false);
+    const [isLoading, setIsLoading] = React.useState(false);
+    const [errors, setErrors] = React.useState<HttpErrorResponse | undefined>(undefined);
+    const [countdown, setCountdown] = React.useState(3);
+    const [redirecting, setRedirecting] = React.useState(false);
+
+    const {register, handleSubmit, formState} = useForm<VerificationSchema>({
+        resolver: zodResolver(verificationFormSchema),
+        reValidateMode: 'onSubmit',
+    });
+
+    React.useEffect(() => {
+        let timer: NodeJS.Timeout | null = null;
+
+        if (redirecting && countdown > 0) {
+            timer = setInterval(() => {
+                setCountdown(prev => prev - 1);
+            }, 1000);
+        } else if (countdown === 0) {
+            router.push('/auth/login');
+            if (timer) clearInterval(timer);
+        }
+
+        return () => {
+            if (timer) clearInterval(timer);
+        };
+    }, [countdown, redirecting, router]);
+
+    async function onSubmit(data: VerificationSchema) {
+        setErrors(undefined);
+        setIsLoading(true);
+
+        httpClient
+            .post('/api/users/verify-email', data)
+            .then((response) => {
+                setSuccess(true);
+                setRedirecting(true);
+            })
+            .catch((error) => {
+                setSuccess(false);
+                const errData = error.response.data as HttpErrorResponse;
+                if (errData.message === 'Email already verified') {
+                    setErrors({...errData, message: "Email already verified, please log in."});
+                    setRedirecting(true);
+                } else {
+                    setErrors(errData);
+                    toast.error(errData.message || 'Verification failed');
+                }
+                console.log(errData);
+            })
+            .finally(() => {
+                setIsLoading(false);
+            });
+    }
+
+    return (
+        <div className="grid gap-6">
+            <SuccessFeedback
+                show={success}
+                message='Account verified successfully'
+                description='You can now login with your email and password.'
+                action={
+                    <Link href='/auth/login' className='underline'>
+                        Login
+                    </Link>
+                }
+                data-test="success-message"
+            />
+            <form onSubmit={handleSubmit(onSubmit)}>
+                <div className="grid gap-4">
+                    <FormInput
+                        id="email"
+                        label="Email"
+                        type="email"
+                        placeholder="name@example.com"
+                        isLoading={isLoading}
+                        register={register}
+                        error={formState.errors.email?.message}
+                        autoComplete="email"
+                        data-test="email-input"
+                    />
+                    <FormInput
+                        id="verificationCode"
+                        label="Verification Code"
+                        type="text"
+                        placeholder="Enter verification code"
+                        isLoading={isLoading}
+                        register={register}
+                        error={formState.errors.verificationCode?.message}
+                        data-test="verification-code-input"
+                    />
+
+                    <ErrorFeedback data-test="error-message" data={errors}/>
+
+                    <Button
+                        disabled={isLoading}
+                        type="submit"
+                        className="mt-6 py-4"
+                        variant="default"
+                        data-test="verify-submit"
+                    >
+                        {isLoading ? 'Verifying...' : 'Verify Email'}
+                    </Button>
+                </div>
+            </form>
+
+            {(redirecting || success) && (
+                <div className="mt-4 text-sm text-gray-500">
+                    You will be redirected to the login page in {countdown}...
+                </div>
+            )}
+        </div>
+    );
+}

--- a/quolance-ui/src/app/(without-main-layout)/auth/verify-email/page.tsx
+++ b/quolance-ui/src/app/(without-main-layout)/auth/verify-email/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+import {VerificationForm} from './components/verification-code';
+import AuthHeader from '@/app/(without-main-layout)/auth/register/components/AuthHeader';
+
+export default function VerificationPage() {
+    return (
+        <>
+            <AuthHeader userRole={undefined}/>
+            <div
+                className="mx-auto mt-4 flex h-full min-w-52 max-w-screen-sm flex-col justify-center space-y-6 pt-24 md:mt-0">
+                <div className="rounded-3xl border p-6">
+                    <div className="my-6 flex flex-col space-y-2 text-center">
+                        <h1 className="text-2xl font-semibold tracking-tight">
+                            Verify Your Email
+                        </h1>
+                        <p className="text-muted-foreground text-sm">
+                            Enter your email and the verification code we sent you
+                        </p>
+                    </div>
+
+                    <VerificationForm/>
+
+                    <div className="relative my-10">
+                        <div className="absolute inset-0 flex items-center">
+                            <span className="w-full border-t"/>
+                        </div>
+                        <div className="relative flex justify-center text-xs uppercase">
+              <span className="text-muted-foreground bg-white px-2">
+                Haven't received the code?
+              </span>
+                        </div>
+                    </div>
+
+                    <p className="flex justify-center gap-x-2 pb-4">
+                        <Link
+                            href="/auth/resend-verification"
+                            className="rounded-lg border px-8 py-2 text-center transition-colors hover:bg-gray-50"
+                        >
+                            Resend verification code
+                        </Link>
+                    </p>
+                </div>
+
+                <p className="flex justify-center gap-x-2">
+                    Already verified?{' '}
+                    <Link
+                        href="/auth/login"
+                        className="underline underline-offset-4"
+                    >
+                        Sign in
+                    </Link>
+                </p>
+
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
# In this PR
## Context:
- Earlier in the project, the verification token that was sent to the user was embedded in the link they receive by email. The link made a direct request to the api. The problem with that was that when we removed the reverse proxy, the request to the backend was always denied, because it was not from a trusted origin.
- To solve this issue, we temporarily set the verification of a user to `true` by default, so that we could continue using the platform while we find a solution.
- Instead of the user verifying the email by clicking on a link, we instead changed it to send a verification code to the email.
- The user needs to type his email and code in the verification page, whose links are available in the email or at the success message upon registration.

## What changed:
- The email that is sent to the users.
- New code verification component
- Backend logic changed for email verification.
- If a user enters a wrong code, a message telling them the code is invalid will appear.
- If the email is already verified, the user will be redirected to the login page

## What's next:
- There is a button to resend the code that does not do anything yet, that will need to be fixed by sending a new code after a few seconds of a user not receiving it.
- We need to deactivate the code after a few minutes, something like a life of 10 minutes, after which the user will need to request a new code if he did not activate his email yet.
- We need a stronger way to generate the code than the current way.

## Video recording
https://github.com/user-attachments/assets/3ac07da9-baaa-4d32-af1e-06e068b56947

## Screenshots
### Success message and link when registering
![image](https://github.com/user-attachments/assets/ba6bfe6f-247e-4090-8566-7bbf9ec9102f)

### Page to validate code
![image](https://github.com/user-attachments/assets/d55c4344-7770-4f8d-9335-0af7a1aa8dd8)

### Received email
![image](https://github.com/user-attachments/assets/26e9e9fa-286a-4a0b-aef4-463eb174114c)

Closes #401
Closes #402 
Closes #403
