### PR TITLE
feat: #409 Deletion of Uploaded Photos and Documents

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FileController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/FileController.java
@@ -1,6 +1,7 @@
 package com.quolance.quolance_api.controllers;
 
 import com.quolance.quolance_api.dtos.FileDto;
+import com.quolance.quolance_api.dtos.paging.PageResponseDto;
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.services.entity_services.FileService;
 import com.quolance.quolance_api.util.SecurityUtil;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,12 +42,25 @@ public class FileController {
         }
     }
 
+    @DeleteMapping("/delete/{fileId}")
+    @Operation(
+            summary = "Delete a file",
+            description = "Deletes a file from the server."
+    )
+    public ResponseEntity<Void> deleteFile(@PathVariable UUID fileId){
+        User user = SecurityUtil.getAuthenticatedUser();
+        log.info("Attempting to delete file with ID {} by user with ID {}", fileId, user.getId());
+        fileService.deleteFile(fileId, user);
+        log.info("Successfully deleted file with ID {} by user with ID {}", fileId, user.getId());
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/all")
     @Operation(
             summary = "Get All User Files",
             description = "Returns all files uploaded by the authenticated user with pagination support."
     )
-    public ResponseEntity<Page<FileDto>> getAllUserFiles(
+    public ResponseEntity<PageResponseDto<FileDto>> getAllUserFiles(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
@@ -57,6 +72,6 @@ public class FileController {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by(sortDirection, sortBy));
         Page<FileDto> files = fileService.getAllFileUploadsByUser(user, pageRequest);
         log.info("Successfully got all files for user with ID {}", user.getId());
-        return ResponseEntity.ok(files);
+        return ResponseEntity.ok(new PageResponseDto<>(files));
     }
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/repositories/FileRepository.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/repositories/FileRepository.java
@@ -7,10 +7,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface FileRepository extends JpaRepository<FileEntity, UUID> {
     void save(FileDto fileDto);
 
     Page<FileEntity> findFileUploadsByUser(User user, Pageable pageable);
+
+    Optional<FileEntity> findByIdAndUserId(UUID fileId, UUID userId);
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/FileService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/FileService.java
@@ -7,10 +7,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
+import java.util.UUID;
 
 public interface FileService {
 
     Map<String, Object> uploadFile(MultipartFile file, User uploadedBy);
+
+    void deleteFile(UUID fileId, User user);
 
     Page<FileDto> getAllFileUploadsByUser(User user, Pageable pageable);
 }

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/FileControllerUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/FileControllerUnitTest.java
@@ -41,6 +41,7 @@ class FileControllerUnitTest {
     private MultipartFile mockFile;
     private FileDto fileDto1;
     private FileDto fileDto2;
+    private UUID mockFileId;
 
     @BeforeEach
     void setUp() {
@@ -48,6 +49,7 @@ class FileControllerUnitTest {
         mockUser.setId(UUID.randomUUID());
         mockUser.setEmail("test@example.com");
         mockUser.setRole(Role.FREELANCER);
+        mockFileId = UUID.randomUUID();
 
         mockFile = new MockMultipartFile(
                 "file",
@@ -103,6 +105,19 @@ class FileControllerUnitTest {
             verify(fileService).uploadFile(mockFile, mockUser);
         }
     }
+
+    @Test
+    void deleteFile_Success() {
+        try (var securityUtil = mockStatic(SecurityUtil.class)) {
+            securityUtil.when(SecurityUtil::getAuthenticatedUser).thenReturn(mockUser);
+
+            ResponseEntity<Void> response = fileController.deleteFile(mockFileId);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(fileService).deleteFile(mockFileId, mockUser);
+        }
+    }
+
 
     @Test
     void getAllUserFiles_ReturnsPageOfFiles() {

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/FileControllerUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/FileControllerUnitTest.java
@@ -2,6 +2,7 @@ package com.quolance.quolance_api.unit.controllers;
 
 import com.quolance.quolance_api.controllers.FileController;
 import com.quolance.quolance_api.dtos.FileDto;
+import com.quolance.quolance_api.dtos.paging.PageResponseDto;
 import com.quolance.quolance_api.entities.User;
 import com.quolance.quolance_api.entities.enums.Role;
 import com.quolance.quolance_api.services.entity_services.FileService;
@@ -115,7 +116,7 @@ class FileControllerUnitTest {
             when(fileService.getAllFileUploadsByUser(mockUser, pageRequest))
                     .thenReturn(filePage);
 
-            ResponseEntity<Page<FileDto>> response = fileController.getAllUserFiles(0, 10, "id", "desc");
+            ResponseEntity<PageResponseDto<FileDto>> response = fileController.getAllUserFiles(0, 10, "id", "desc");
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();
@@ -136,7 +137,7 @@ class FileControllerUnitTest {
             when(fileService.getAllFileUploadsByUser(mockUser, pageRequest))
                     .thenReturn(emptyPage);
 
-            ResponseEntity<Page<FileDto>> response = fileController.getAllUserFiles(0, 10, "id", "desc");
+            ResponseEntity<PageResponseDto<FileDto>> response = fileController.getAllUserFiles(0, 10, "id", "desc");
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();
@@ -157,7 +158,7 @@ class FileControllerUnitTest {
             when(fileService.getAllFileUploadsByUser(mockUser, pageRequest))
                     .thenReturn(filePage);
 
-            ResponseEntity<Page<FileDto>> response = fileController.getAllUserFiles(0, 5, "id", "desc");
+            ResponseEntity<PageResponseDto<FileDto>> response = fileController.getAllUserFiles(0, 5, "id", "desc");
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();
@@ -179,7 +180,7 @@ class FileControllerUnitTest {
             when(fileService.getAllFileUploadsByUser(mockUser, pageRequest))
                     .thenReturn(filePage);
 
-            ResponseEntity<Page<FileDto>> response = fileController.getAllUserFiles(0, 10, "fileName", "desc");
+            ResponseEntity<PageResponseDto<FileDto>> response = fileController.getAllUserFiles(0, 10, "fileName", "desc");
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();
@@ -201,7 +202,7 @@ class FileControllerUnitTest {
             when(fileService.getAllFileUploadsByUser(mockUser, pageRequest))
                     .thenReturn(filePage);
 
-            ResponseEntity<Page<FileDto>> response = fileController.getAllUserFiles(0, 10, "id", "asc");
+            ResponseEntity<PageResponseDto<FileDto>> response = fileController.getAllUserFiles(0, 10, "id", "asc");
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).isNotNull();


### PR DESCRIPTION
## Overview  
This PR implements file deletion functionality, ensuring files are removed from both Cloudinary and the database. It also includes a quick fix to simplify the `getAllFiles` endpoint response.  

## Changes  
- Implemented file deletion that removes files from **Cloudinary** and **database**.  
- Refactored `getAllFiles` endpoint to be **less cluttered**.  

## Implementation Details  
### File Deletion  
- Extracts **public ID** from Cloudinary file URLs.  
- Deletes the file from **Cloudinary** using `cloudinary.uploader().destroy()`.  
- Removes the file record from the **database**.  

### `getAllFiles` Endpoint Fix  
- Now using PageResponseDto instead of Page. Less Clutter

## Usage Examples  
### File Deletion API  
`DELETE /delete/{fileId}`  
- Deletes the file from **Cloudinary** and **database**.  

### Expected Responses  
#### ✅ Successful Deletion  
**Status:** `200 OK`  

#### ❌ File Not Found  
**Status:** `400 Bad Request`  
**Message:** `"File not found in user's uploads"`  

#### ❌ Unauthorized Access  
**Status:** `401 Unauthorized`  

closes #409 
