### PR TITLE
bugfix: #416 Added ai model name to environment variable

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/GeminiConfig.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/GeminiConfig.java
@@ -11,8 +11,13 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Data
 public class GeminiConfig {
     private String key;
-    private String baseUrl = "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent";
+    private String model;
+    private String baseUrl;
 
+    public void setModel(String model) {
+        this.model = model;
+        this.baseUrl = "https://generativelanguage.googleapis.com/v1/models/" + model + ":generateContent";
+    }
     @Bean
     public WebClient geminiWebClient() {
         return WebClient.builder()

--- a/quolance-api/src/main/resources/application.yml
+++ b/quolance-api/src/main/resources/application.yml
@@ -101,3 +101,4 @@ cloudinary:
 google:
   api:
     key: ${GOOGLE_API_KEY}
+    model: ${MODEL_NAME}

--- a/quolance-api/src/main/resources/toggles.properties
+++ b/quolance-api/src/main/resources/toggles.properties
@@ -1,1 +1,1 @@
-feature.toggles.toggles.useAiProjectEvaluation=false
+feature.toggles.toggles.useAiProjectEvaluation=true


### PR DESCRIPTION
The fix in this PR sets the model name for the gemini service as a variable that can be easily changed in case Google updates their models. Previously, we had `gemini-pro` and this PR fixes the problem where the model was not available anymore.