### PR TITLE
bugfix: #418 changed rejection after AI evaluation only if manual approval is not needed

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
@@ -273,7 +273,7 @@ public class ProjectServiceImpl implements ProjectService {
                 && result.getConfidenceScore() >= 0.8) {
             updateProjectStatus(project, ProjectStatus.OPEN);
         } else if (!result.isApproved()
-                && result.getConfidenceScore() >= 0.9) {
+                && result.getConfidenceScore() >= 0.9 && !result.isRequiresManualReview()) {
             updateProjectStatus(project, ProjectStatus.REJECTED);
         }
         log.info("Moderation status for project with ID {}: approved={}, review={}", project.getId(), result.isApproved(), result.isRequiresManualReview());


### PR DESCRIPTION
Fixed a bug where a project was set to REJECTED after the moderation service flags it as not accepted AND needing approval.

Closes #418 