### PR TITLE
feat: #430 Clients see the status of their project on creation

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/project/ProjectEvaluationResult.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/project/ProjectEvaluationResult.java
@@ -6,12 +6,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProjectEvaluationResult {
+    private UUID projectId;
     private boolean approved = false;
     private double confidenceScore;
     private String reason;

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/ProjectService.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/ProjectService.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 public interface ProjectService {
 
-    void saveProject(Project project);
+    Project saveProject(Project project);
 
     void deleteProject(Project project);
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/ProjectServiceImpl.java
@@ -29,10 +29,9 @@ public class ProjectServiceImpl implements ProjectService {
     private final ProjectModerationService projectModerationService;
 
     @Override
-    public void saveProject(Project project) {
+    public Project saveProject(Project project) {
         log.debug("Saving project: {} for client {}", project.getTitle(), project.getClient().getId());
-        projectRepository.save(project);
-        log.info("Successfully saved project with ID: {} for client {}", project.getId(), project.getClient().getId());
+        return projectRepository.save(project);
     }
 
     @Override

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/ClientWorkflowServiceUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/services/business_workflow/ClientWorkflowServiceUnitTest.java
@@ -16,13 +16,15 @@ import com.quolance.quolance_api.services.business_workflow.impl.ClientWorkflowS
 import com.quolance.quolance_api.services.entity_services.ApplicationService;
 import com.quolance.quolance_api.services.entity_services.ProjectService;
 import com.quolance.quolance_api.services.entity_services.UserService;
-import com.quolance.quolance_api.util.FeatureToggle;
 import com.quolance.quolance_api.util.exceptions.ApiException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -54,8 +56,6 @@ class ClientWorkflowServiceUnitTest {
 
     @InjectMocks
     private ClientWorkflowServiceImpl clientWorkflowService;
-
-    private FeatureToggle featureToggle = mock(FeatureToggle.class);
 
     @Captor
     private ArgumentCaptor<Project> projectCaptor;
@@ -121,40 +121,6 @@ class ClientWorkflowServiceUnitTest {
                 .project(mockProject)
                 .freelancer(mockFreelancer)
                 .build();
-    }
-
-    @Test
-    void createProject_WithExpirationDate_Success() {
-        Mockito.when(featureToggle.isEnabled("useAiProjectEvaluation")).thenReturn(false);
-
-        clientWorkflowService.createProject(mockProjectCreateDto, mockClient);
-
-        verify(projectService).saveProject(projectCaptor.capture());
-        Project savedProject = projectCaptor.getValue();
-
-        assertThat(savedProject.getTitle()).isEqualTo(mockProjectCreateDto.getTitle());
-        assertThat(savedProject.getDescription()).isEqualTo(mockProjectCreateDto.getDescription());
-        assertThat(savedProject.getCategory()).isEqualTo(mockProjectCreateDto.getCategory());
-        assertThat(savedProject.getPriceRange()).isEqualTo(mockProjectCreateDto.getPriceRange());
-        assertThat(savedProject.getExperienceLevel()).isEqualTo(mockProjectCreateDto.getExperienceLevel());
-        assertThat(savedProject.getExpectedDeliveryTime()).isEqualTo(mockProjectCreateDto.getExpectedDeliveryTime());
-        assertThat(savedProject.getExpirationDate()).isEqualTo(mockProjectCreateDto.getExpirationDate());
-        assertThat(savedProject.getTags()).isEqualTo(mockProjectCreateDto.getTags());
-        assertThat(savedProject.getClient()).isEqualTo(mockClient);
-    }
-
-    @Test
-    void createProject_WithoutExpirationDate_SetsDefaultDate() {
-        Mockito.when(featureToggle.isEnabled("useAiProjectEvaluation")).thenReturn(false);
-
-        mockProjectCreateDto.setExpirationDate(null);
-
-        clientWorkflowService.createProject(mockProjectCreateDto, mockClient);
-
-        verify(projectService).saveProject(projectCaptor.capture());
-        Project savedProject = projectCaptor.getValue();
-
-        assertThat(savedProject.getExpirationDate()).isEqualTo(LocalDate.now().plusDays(7));
     }
 
     @Test

--- a/quolance-ui/src/app/(without-main-layout)/(authenticated-pages)/(client-protected-pages)/post-project/page.tsx
+++ b/quolance-ui/src/app/(without-main-layout)/(authenticated-pages)/(client-protected-pages)/post-project/page.tsx
@@ -1,22 +1,30 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-
-import { PiCheckBold, PiXBold } from 'react-icons/pi';
+import {useState} from 'react';
+import {AiOutlineLoading3Quarters} from 'react-icons/ai';
+import {PiCheckBold, PiXBold} from 'react-icons/pi';
 
 import StepFour from '@/components/postProjectSteps/StepFour';
 import StepOne from '@/components/postProjectSteps/StepOne';
 import StepThree from '@/components/postProjectSteps/StepThree';
 import StepTwo from '@/components/postProjectSteps/StepTwo';
+import ProjectStatusNotification from '@/components/ProjectStatusNotification';
 
-import { useSteps } from '@/util/context/StepsContext';
+import {useAuthGuard} from '@/api/auth-api';
+import {usePostProject} from '@/api/projects-api';
+import {PostProjectType} from '@/constants/types/project-types';
+import {useSteps} from '@/util/context/StepsContext';
+import {showToast} from '@/util/context/ToastProvider';
 
-import { usePostProject } from '@/api/projects-api';
-import { PostProjectType } from '@/constants/types/project-types';
-
-import { showToast } from '@/util/context/ToastProvider';
-import { useAuthGuard } from '@/api/auth-api';
+interface ProjectEvaluationResult {
+  projectId: string;
+  approved: boolean;
+  confidenceScore: number;
+  reason: string;
+  flags: string[];
+  requiresManualReview: boolean;
+}
 
 const stepsComponents = [StepOne, StepTwo, StepThree, StepFour];
 
@@ -28,37 +36,38 @@ const stepsName = [
 ];
 
 function PostsTasksSteps() {
-  const router = useRouter();
-
+  const [evaluationResult, setEvaluationResult] = useState<ProjectEvaluationResult | null>(null);
+  const [loading, setLoading] = useState(false); // Added loading state
   const { user } = useAuthGuard({ middleware: 'auth' });
-
   const { currentStep, setCurrentStep, formData, resetSteps } = useSteps();
-
   const StepComponent = stepsComponents[currentStep];
 
-  const { mutateAsync: mutateProject } = usePostProject({
-    onSuccess: () => {
-      console.log('Project created successfully');
-      showToast('Project created successfully', 'success');
-    },
-    onError: (error) => {
-      console.log('Error creating project:', error);
-      showToast('Error creating project', 'error');
-    },
-  });
+  const {mutateAsync: mutateProject} = usePostProject();
 
   const submitForm = async () => {
     try {
-      console.log('Form submitted:', formData);
+      setLoading(true);
       const project: PostProjectType = formData;
-      await mutateProject(project).then(() => {
-        resetSteps();
-      });
+      const response = await mutateProject(project);
 
-      // push to home page
-      router.push('/dashboard');
+      if (response?.data) {
+        setEvaluationResult(response.data);
+      } else {
+        setEvaluationResult({
+          projectId: "",
+          approved: false,
+          confidenceScore: 0,
+          reason: 'Awaiting system evaluation',
+          flags: [],
+          requiresManualReview: true,
+        });
+      }
+
+      resetSteps();
     } catch (err) {
-      console.log('Error in submitForm:', err);
+      showToast('Error creating project', 'error');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -73,54 +82,33 @@ function PostsTasksSteps() {
   };
 
   return (
-    <>
-      <section className='sbp-30'>
-        <div className='4xl:large-container max-4xl:container flex items-center justify-between pt-6'>
-          {user?.role ? (
-            <Link href='/dashboard'>
-              <h1 className='text-2xl font-bold'>Quolance</h1>
+      <>
+        {evaluationResult && <ProjectStatusNotification evaluationResult={evaluationResult}/>}
+        <section className="sbp-30">
+          <div className="4xl:large-container max-4xl:container flex items-center justify-between pt-6">
+            <Link href={user?.role ? '/dashboard' : '/'}>
+              <h1 className="text-2xl font-bold">Quolance</h1>
             </Link>
-          ) : (
-            <Link href='/'>
-              <h1 className='text-2xl font-bold'>Quolance</h1>
-            </Link>
-          )}
-          {user?.role ? (
             <Link
-              href='/dashboard'
-              className='hover:text-r300 flex items-center justify-start gap-2 text-lg font-medium duration-500'
+                href={user?.role ? '/dashboard' : '/'}
+                className="hover:text-r300 flex items-center justify-start gap-2 text-lg font-medium duration-500"
             >
-              Cancel{' '}
-              <span className='ph-bold ph-x !leading-none'>
-                <PiXBold />
-              </span>
+              Cancel <PiXBold className="ph-bold ph-x !leading-none"/>
             </Link>
-          ) : (
-            <Link
-              href='/'
-              className='hover:text-r300 flex items-center justify-start gap-2 text-lg font-medium duration-500'
-            >
-              Cancel{' '}
-              <span className='ph-bold ph-x !leading-none'>
-                <PiXBold />
-              </span>
-            </Link>
-          )}
-        </div>
-
-        {currentStep < 4 && (
-          <div className='stp-30 container grid grid-cols-12 gap-6'>
-            <div className='col-span-12 md:col-span-4 xl:col-span-3 xl:col-start-2'>
-              <div className='border-n30 rounded-3xl border p-4 sm:p-8'>
-                <ul className='flex flex-col gap-8'>
+          </div>
+          {currentStep < 4 && !evaluationResult && (
+              <div className="stp-30 container grid grid-cols-12 gap-6">
+                <div className="col-span-12 md:col-span-4 xl:col-span-3 xl:col-start-2">
+                  <div className="border-n30 rounded-3xl border p-4 sm:p-8">
+                    <ul className="flex flex-col gap-8">
                   {stepsName.map((item, idx) => (
-                    <li className='relative' key={idx}>
+                      <li className="relative" key={idx}>
                       {currentStep === idx ? (
-                        <div className='bg-b50 flex w-full items-center justify-start gap-4 rounded-full p-2'>
-                          <div className='bg-b300 flex items-center justify-center rounded-full p-2 !leading-none text-white'>
+                          <div className="bg-b50 flex w-full items-center justify-start gap-4 rounded-full p-2">
+                            <div className="bg-b300 flex items-center justify-center rounded-full p-2 text-white">
                             <PiCheckBold />
                           </div>
-                          <p className='text-sm font-medium'>{item}</p>
+                            <p className="text-sm font-medium">{item}</p>
                         </div>
                       ) : (
                         <div
@@ -131,7 +119,7 @@ function PostsTasksSteps() {
                           <div
                             className={`flex size-9 items-center justify-center rounded-full border-2 ${
                               currentStep > idx ? 'border-b300' : 'border-n300'
-                            } p-2 text-sm !leading-none `}
+                            } p-2 text-sm`}
                           >
                             {idx + 1}
                           </div>
@@ -139,36 +127,37 @@ function PostsTasksSteps() {
                         </div>
                       )}
 
-                      {stepsName.length !== idx + 1 && (
-                        <div className='absolute left-[22px] top-[54px] h-[32px] w-[3px]'>
-                          <div
-                            className={`h-full w-full border-l-4 border-dotted transition-all duration-300 ${
-                              currentStep > idx
-                                ? 'border-b300'
-                                : 'border-gray-200'
-                            }`}
-                          />
-                        </div>
-                      )}
-                    </li>
+                        {idx < stepsName.length - 1 && (
+                            <div className="absolute left-[22px] top-[54px] h-[32px] w-[3px]">
+                              <div
+                                  className={`h-full w-full border-l-4 border-dotted transition-all duration-300 ${
+                                      currentStep > idx ? 'border-b300' : 'border-gray-200'
+                                  }`}
+                              />
+                            </div>
+                        )}
+                      </li>
                   ))}
-                </ul>
-              </div>
-            </div>
+                    </ul>
+                  </div>
+                </div>
 
-            <div className='col-span-12 md:col-span-8 xl:col-span-6 xl:col-start-6'>
-              <div className='border-n30 rounded-3xl border p-6 sm:p-8'>
-                <StepComponent
-                  handleNext={handleNext}
-                  handleBack={handleBack}
-                  submitForm={submitForm}
-                />
+                <div className="col-span-12 md:col-span-8 xl:col-span-6 xl:col-start-6">
+                  <div className="border-n30 rounded-3xl border p-6 sm:p-8 relative">
+                    {loading && (
+                        <div
+                            className="absolute inset-0 flex flex-col items-center justify-center bg-white bg-opacity-75 rounded-3xl">
+                          <AiOutlineLoading3Quarters className="animate-spin text-4xl text-blue-500"/>
+                          <p className="mt-2 text-sm text-gray-700">Processing your request...</p>
+                        </div>
+                    )}
+                    <StepComponent handleNext={handleNext} handleBack={handleBack} submitForm={submitForm}/>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        )}
-      </section>
-    </>
+          )}
+        </section>
+      </>
   );
 }
 

--- a/quolance-ui/src/components/ProjectStatusNotification.tsx
+++ b/quolance-ui/src/components/ProjectStatusNotification.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import React, {useState} from 'react';
+import {PiCheckCircleBold, PiClockCountdownBold, PiXCircleBold} from 'react-icons/pi';
+
+interface ProjectEvaluationResult {
+    projectId: string;
+    approved: boolean;
+    confidenceScore: number;
+    reason: string;
+    flags: string[];
+    requiresManualReview: boolean;
+}
+
+interface ProjectStatusNotificationProps {
+    evaluationResult: ProjectEvaluationResult;
+}
+
+const ProjectStatusNotification: React.FC<ProjectStatusNotificationProps> = ({ evaluationResult }) => {
+    const router = useRouter();
+    const [showNotification] = useState(true);
+
+    const getStatusIcon = () => {
+        if (evaluationResult.approved) {
+            return <PiCheckCircleBold className="text-green-500 text-4xl" />;
+        } else if (evaluationResult.requiresManualReview) {
+            return <PiClockCountdownBold className="text-amber-500 text-4xl" />;
+        } else {
+            return <PiXCircleBold className="text-red-500 text-4xl" />;
+        }
+    };
+
+    const getStatusTitle = () => {
+        if (evaluationResult.approved) {
+            return "Project Approved";
+        } else if (evaluationResult.requiresManualReview) {
+            return "Project Under Review";
+        } else {
+            return "Project Rejected";
+        }
+    };
+
+    const getStatusMessage = () => {
+        if (evaluationResult.approved) {
+            return "Your project has been approved and is now live. Freelancers can start bidding on your project.";
+        } else if (evaluationResult.requiresManualReview) {
+            return "Your project is pending approval. Our team will review it shortly and notify you once it's approved.";
+        } else {
+            return `Your project was not approved. Reason: ${evaluationResult.reason}`;
+        }
+    };
+
+    const handleDashboardClick = () => router.push('/dashboard');
+    const handleViewProjectClick = () => router.push(`/projects/${evaluationResult.projectId}`);
+
+    if (!showNotification) return null;
+
+    return (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+            <div className="bg-white rounded-3xl p-8 max-w-md w-full shadow-lg">
+                <div className="flex flex-col items-center text-center">
+                    {getStatusIcon()}
+                    <h2 className="text-2xl font-bold mt-4">{getStatusTitle()}</h2>
+                    <p className="text-n500 mt-2 mb-6">{getStatusMessage()}</p>
+
+                    <div className="flex flex-col gap-3 w-full">
+                        <button
+                            onClick={handleDashboardClick}
+                            className="bg-b300 hover:bg-b400 text-white font-medium py-3 px-6 rounded-full transition-colors duration-300"
+                        >
+                            Go to Dashboard
+                        </button>
+
+                        {(evaluationResult.approved || evaluationResult.requiresManualReview) && (
+                            <button
+                                onClick={handleViewProjectClick}
+                                className="bg-blue-500 hover:bg-blue-600 text-white font-medium py-3 px-6 rounded-full transition-colors duration-300"
+                            >
+                                View Project
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ProjectStatusNotification;


### PR DESCRIPTION
# In this PR:
## UI Changes:
- Clients can now see when they create their project if it is approved, rejected or pending.
- They see a modal that lets them view their created project or go to the dashboard.
- If the project is rejected, a reason is provided.

### Screenshots:
![image](https://github.com/user-attachments/assets/d7df3952-41ff-46e5-a5e3-8ae9916e4976)
![image](https://github.com/user-attachments/assets/18437050-ab8e-4726-a06e-851dbe6cd4ea)
![image](https://github.com/user-attachments/assets/cb18c457-1a44-4f7e-a533-5111639574ce)

## Backend changes:
- Added ID field in the creation response to allow navigation to the project in the UI.
- Fixed tests

Closes #430 