### PR TITLE
feat: #318 Added tags on blog posts upon creation

### DIFF
--- a/quolance-ui/src/api/blog-api.ts
+++ b/quolance-ui/src/api/blog-api.ts
@@ -20,7 +20,7 @@ export const useCreateBlogPost = (options?: {
   onError?: (error: unknown) => void;
 }) => {
   return useMutation({
-    mutationFn: (blogpost: { title: string; content: string; userId?: string; files?: File[] }) => {
+    mutationFn: (blogpost: { title: string; content: string; userId?: string; tags: string[]; files?: File[] }) => {
       if (!blogpost.userId) {
         throw new Error("User ID is undefined. User must be logged in.");
       }
@@ -29,6 +29,7 @@ export const useCreateBlogPost = (options?: {
       formData.append("title", blogpost.title);
       formData.append("content", blogpost.content);
       formData.append("userId", String(blogpost.userId));
+      blogpost.tags.forEach(tag => formData.append("tags", tag));
 
       if (blogpost.files && blogpost.files.length > 0) {
         blogpost.files.forEach((file) => {

--- a/quolance-ui/src/components/ui/blog/BlogContainer.tsx
+++ b/quolance-ui/src/components/ui/blog/BlogContainer.tsx
@@ -71,6 +71,7 @@ const BlogContainer: React.FC = () => {
         content: string;
         userId: string | undefined;
         files?: File[]
+        tags: string[];
     }) => {
         if (!postData.userId) {
             showToast("Error: User not logged in.", "error");

--- a/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
@@ -4,17 +4,18 @@ import React, { useState } from 'react';
 import { useAuthGuard } from '@/api/auth-api';
 import { Button } from '../button';
 
+const mockTags = ['Web-development', 'React', 'JavaScript', 'TypeScript', 'Node.js', 'Express', 'MongoDB', 'GraphQL', 'REST', 'API', 'Frontend', 'Backend', 'Fullstack', 'UI/UX', 'Design', 'Testing'];
+
 interface CreatePostFormProps {
-  // onSubmit: (postData: { title: string; content: string; tags: string[] }) => void;
   onSubmit: (postData: { title: string; content: string; userId: string | undefined; files?: File[]  }) => void;
   onClose: () => void;
 }
 
 const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) => {
-  const { user } = useAuthGuard({ middleware: 'auth' }); // Get the authenticated user
+  const { user } = useAuthGuard({ middleware: 'auth' });
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
-  //const [tags, setTags] = useState<string>('');
+  const [tags, setTags] = useState<string[]>([]);
   const [error, setError] = useState('');
   const [files, setFiles] = useState<File[]>([]);
 
@@ -39,6 +40,17 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
     setFiles((prevFiles) => prevFiles.filter((_, i) => i !== index));
   };
 
+  const handleTagSelection = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedValue = e.target.value;
+    if (!tags.includes(selectedValue)) {
+      setTags((prevTags) => [...prevTags, selectedValue]);
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setTags((prevTags) => prevTags.filter((t) => t !== tag));
+  };
+
   const handleFormSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -57,6 +69,7 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
     setTitle('');
     setContent('');
     setFiles([]);
+    setTags([]);
     setError('');
     onClose();
   };
@@ -87,6 +100,41 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
           className="w-full p-2 border rounded-md"
           rows={5}
         />
+      </div>
+
+      <div>
+        <label className="block text-gray-700 font-medium mb-1">Tags</label>
+        <select
+          id="tags"
+          title="Select tags"
+          onChange={handleTagSelection} 
+          className="w-full p-2 border rounded-md"
+        >
+          <option value="">Select a tag</option>
+          {mockTags.map((tag) => (
+            <option key={tag} value={tag}>
+              {tag}
+            </option>
+          ))}
+        </select>
+
+        <div className="mt-2 flex flex-wrap gap-2">
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {tags.map((tag) => (
+                <span key={tag} className="bg-gray-200 px-2 py-1 rounded-md flex items-center text-sm">
+                  {tag}
+                  <button
+                    onClick={() => handleRemoveTag(tag)}
+                    className="ml-2 text-red-500"
+                  >
+                    ✖
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* File Drop Area */}

--- a/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
@@ -3,8 +3,28 @@
 import React, { useState } from 'react';
 import { useAuthGuard } from '@/api/auth-api';
 import { Button } from '../button';
+import { 
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+ } from '../dropdown-menu';
 
-const mockTags = ['Web-development', 'React', 'JavaScript', 'TypeScript', 'Node.js', 'Express', 'MongoDB', 'GraphQL', 'REST', 'API', 'Frontend', 'Backend', 'Fullstack', 'UI/UX', 'Design', 'Testing'];
+const blogTags = [
+  'Question',
+  'Support',
+  'Freelancing',
+  'Skill Matching',
+  'Remote Work',
+  'AI Suggestions',
+  'Security',
+  'Talent Marketplace',
+  'Global Opportunities',
+  'Verified Profiles',
+  'Collaboration Tools',
+  'Professional Network',
+  'Billing',
+];
 
 interface CreatePostFormProps {
   onSubmit: (postData: { title: string; content: string; userId: string | undefined; files?: File[]  }) => void;
@@ -40,10 +60,9 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
     setFiles((prevFiles) => prevFiles.filter((_, i) => i !== index));
   };
 
-  const handleTagSelection = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedValue = e.target.value;
-    if (!tags.includes(selectedValue)) {
-      setTags((prevTags) => [...prevTags, selectedValue]);
+  const handleTagSelection = (tag: string) => {
+    if (!tags.includes(tag)) {
+      setTags((prevTags) => [...prevTags, tag]);
     }
   };
 
@@ -104,37 +123,43 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
 
       <div>
         <label className="block text-gray-700 font-medium mb-1">Tags</label>
-        <select
-          id="tags"
-          title="Select tags"
-          onChange={handleTagSelection} 
-          className="w-full p-2 border rounded-md"
-        >
-          <option value="">Select a tag</option>
-          {mockTags.map((tag) => (
-            <option key={tag} value={tag}>
-              {tag}
-            </option>
-          ))}
-        </select>
 
-        <div className="mt-2 flex flex-wrap gap-2">
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-1 mt-2">
-              {tags.map((tag) => (
-                <span key={tag} className="bg-gray-200 px-2 py-1 rounded-md flex items-center text-sm">
-                  {tag}
-                  <button
-                    onClick={() => handleRemoveTag(tag)}
-                    className="ml-2 text-red-500"
-                  >
-                    ✖
-                  </button>
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="w-full p-2 border rounded-md bg-white text-left">
+              Select a tag
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-full bg-white">
+            {blogTags.map((tag) => (
+              <DropdownMenuItem
+                key={tag}
+                onSelect={() => handleTagSelection(tag)}
+                className={`p-2 cursor-pointer hover:bg-gray-200 ${
+                  tags.includes(tag) ? 'bg-gray-300' : ''
+                }`}
+              >
+                {tag}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {tags.map((tag) => (
+              <span key={tag} className="bg-gray-200 px-2 py-1 rounded-md flex items-center text-sm">
+                {tag}
+                <button
+                  onClick={() => handleRemoveTag(tag)}
+                  className="ml-2 text-red-500"
+                >
+                  ✖
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* File Drop Area */}

--- a/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
@@ -62,7 +62,7 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
   };
 
   return (
-    <form onSubmit={handleFormSubmit} className="space-y-4">
+    <form onSubmit={handleFormSubmit} className="space-y-4 m-2">
       <h2 className="text-lg font-bold mb-4">Create a New Post</h2>
 
       {error && <p className="text-red-500">{error}</p>}

--- a/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
@@ -10,24 +10,24 @@ import {
   DropdownMenuItem,
  } from '../dropdown-menu';
 
-const blogTags = [
-  'Question',
-  'Support',
-  'Freelancing',
-  'Skill Matching',
-  'Remote Work',
-  'AI Suggestions',
-  'Security',
-  'Talent Marketplace',
-  'Global Opportunities',
-  'Verified Profiles',
-  'Collaboration Tools',
-  'Professional Network',
-  'Billing',
+ const blogTags = [
+  { label: 'Question', value: 'QUESTION' },
+  { label: 'Support', value: 'SUPPORT' },
+  { label: 'Freelancing', value: 'FREELANCING' },
+  { label: 'Skill Matching', value: 'SKILL_MATCHING' },
+  { label: 'Remote Work', value: 'REMOTE_WORK' },
+  { label: 'AI Suggestions', value: 'AI_SUGGESTIONS' },
+  { label: 'Security', value: 'SECURITY' },
+  { label: 'Talent Marketplace', value: 'TALENT_MARKETPLACE' },
+  { label: 'Global Opportunities', value: 'GLOBAL_OPPORTUNITIES' },
+  { label: 'Verified Profiles', value: 'VERIFIED_PROFILES' },
+  { label: 'Collaboration Tools', value: 'COLLABORATION_TOOLS' },
+  { label: 'Professional Network', value: 'PROFESSIONAL_NETWORK' },
+  { label: 'Billing', value: 'BILLING' },
 ];
 
 interface CreatePostFormProps {
-  onSubmit: (postData: { title: string; content: string; userId: string | undefined; files?: File[]  }) => void;
+  onSubmit: (postData: { title: string; content: string; userId: string | undefined; tags: string[]; files?: File[]  }) => void;
   onClose: () => void;
 }
 
@@ -83,8 +83,9 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
       return;
     }
 
+    console.log({ title, content, tags });
 
-    onSubmit({ title, content, userId: user?.id, files });
+    onSubmit({ title, content, userId: user?.id, tags, files });
     setTitle('');
     setContent('');
     setFiles([]);
@@ -133,13 +134,13 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
           <DropdownMenuContent className="w-full bg-white">
             {blogTags.map((tag) => (
               <DropdownMenuItem
-                key={tag}
-                onSelect={() => handleTagSelection(tag)}
+                key={tag.value}
+                onSelect={() => handleTagSelection(tag.value)}
                 className={`p-2 cursor-pointer hover:bg-gray-200 ${
-                  tags.includes(tag) ? 'bg-gray-300' : ''
+                  tags.includes(tag.value) ? 'bg-gray-300' : ''
                 }`}
               >
-                {tag}
+                {tag.label}
               </DropdownMenuItem>
             ))}
           </DropdownMenuContent>
@@ -149,7 +150,7 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
           <div className="mt-2 flex flex-wrap gap-2">
             {tags.map((tag) => (
               <span key={tag} className="bg-gray-200 px-2 py-1 rounded-md flex items-center text-sm">
-                {tag}
+                {blogTags.find((t) => t.value === tag)?.label || tag}
                 <button
                   onClick={() => handleRemoveTag(tag)}
                   className="ml-2 text-red-500"

--- a/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
@@ -27,7 +27,7 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ open, onClose, childr
     return open ? (
         <dialog ref={dialogRef} className="dialog">
             <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
-                <div className="bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[80vh] overflow-auto p-4 relative">
+                <div className="bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[100vh] overflow-auto p-4 relative">
                     {/* Close Button */}
                     <button
                         onClick={closeDialog}
@@ -37,7 +37,7 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ open, onClose, childr
                     </button>
 
                     {/* Content Area */}
-                    <div className="overflow-y-auto max-h-[60vh]">
+                    <div className="overflow-y-auto max-h-[70vh]">
                         {children}
                     </div>
                 </div>

--- a/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
@@ -26,20 +26,18 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ open, onClose, childr
 
     return open ? (
         <dialog ref={dialogRef} className="dialog">
-            <div className="fixed inset-0 flex justify-center items-center bg-gray-900 bg-opacity-50 z-50">
-                <div className="bg-white p-6 rounded-lg shadow-md w-[90%] max-w-4xl h-[60%] max-h-[60%] overflow-hidden">
+            <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+                <div className="bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[80vh] overflow-auto p-4 relative">
                     {/* Close Button */}
-                    <div className="flex justify-end">
-                        <button
-                            onClick={closeDialog}
-                            className="text-gray-500 text-2xl hover:text-red-600"
-                        >
-                            ✖
-                        </button>
-                    </div>
+                    <button
+                        onClick={closeDialog}
+                        className="absolute top-4 right-4 text-gray-500 hover:text-red-700"
+                    >
+                        ✖
+                    </button>
 
                     {/* Content Area */}
-                    <div className="overflow-auto h-full space-y-4">
+                    <div className="overflow-y-auto max-h-[60vh]">
                         {children}
                     </div>
                 </div>

--- a/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
@@ -27,7 +27,7 @@ const CreatePostModal: React.FC<CreatePostModalProps> = ({ open, onClose, childr
     return open ? (
         <dialog ref={dialogRef} className="dialog">
             <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
-                <div className="bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[100vh] overflow-auto p-4 relative">
+                <div className="bg-white rounded-xl shadow-xl max-w-screen-sm w-screen max-h-[100vh] overflow-auto p-4 relative">
                     {/* Close Button */}
                     <button
                         onClick={closeDialog}

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -35,12 +35,13 @@ interface PostCardProps {
   content: string;
   authorName: string;
   dateCreated: string;
+  tags?: string[];
   imageUrls?: string[];
   openUserSummaryPostId: string | null;
   setOpenUserSummaryPostId: (open: string | null) => void;
 }
 
-const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dateCreated, imageUrls = [], openUserSummaryPostId, setOpenUserSummaryPostId }) => {
+const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dateCreated, tags, imageUrls = [], openUserSummaryPostId, setOpenUserSummaryPostId }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [showComments, setShowComments] = useState(false);
   const [newComment, setNewComment] = useState<string>("");
@@ -471,6 +472,16 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
           >
             {isExpanded ? "Read less" : "Read more"}
           </button>
+        )}
+
+        {tags && tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-2">
+            {tags.map((tag) => (
+              <span key={tag} className="bg-blue-100 text-blue-800 px-2 py-1 rounded-md text-xs font-semibold">
+                {tag.replace(/_/g, ' ')}
+              </span>
+            ))}
+          </div>
         )}
 
         {/* Reaction Buttons */}


### PR DESCRIPTION
# **Pull Request: Add Tag on Blog Posts Upon Creation**  

## **Summary**  
This PR introduces **tag selection** during post creation and **tag display** on blog posts. Users can now choose multiple tags when creating a post. Additionally, blog posts now display their associated tag.

---

## **Key Changes**

### **Tag Selection During Post Creation**
- Integrated **dropdown menu** for selecting tags when creating a post.
- Ensured **multiple tag selection** is possible.
- Prevented duplicate selections.
- Added the ability to **remove selected tags** before submitting.  

### **Displaying Tags on Blog Posts**
- Updated `PostCard` component to **display tags** under the post title.

---

## **Future Enhancements**
- Fetch **available tags dynamically** from the backend instead of using a static list.
- Allow **tag-based filtering** of blog posts and tag-based **search functionality**.

---

## **Screenshots**  
### **Tag Selection in Create Post Modal**  
![image](https://github.com/user-attachments/assets/6bd6eaff-903e-4927-be0c-df2bcd398111)

### **Tags Displayed on Blog Posts**  
![image](https://github.com/user-attachments/assets/fa0390df-0266-4593-8537-ef873f0ab22b)

---

✅ Closes #318