### PR TITLE
bugfix: #440 Clients see in their dashboards other client projects

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/business_workflow/impl/ClientWorkflowServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/business_workflow/impl/ClientWorkflowServiceImpl.java
@@ -93,6 +93,8 @@ public class ClientWorkflowServiceImpl implements ClientWorkflowService {
         Specification<Project> spec = (root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
 
+            predicates.add(criteriaBuilder.equal(root.get("client").get("id"), client.getId()));
+
             // Add search filters if provided
             if (filters != null) {
                 if (filters.getSearchTitle() != null && !filters.getSearchTitle().trim().isEmpty()) {


### PR DESCRIPTION
## Description
This PR addresses the bug that allowed clients to view other user's projects on their dashboard.

## Implementation:
- Added an ID check before retrieving projects.