### PR TITLE
bugfix: #444 Username null in Client getAllFreelancers

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/profile/FreelancerProfileDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/profile/FreelancerProfileDto.java
@@ -50,6 +50,7 @@ public class FreelancerProfileDto {
                 .userId(user.getId())
                 .firstName(user.getFirstName())
                 .lastName(user.getLastName())
+                .username(user.getUsername())
                 .profileImageUrl(user.getProfileImageUrl())
                 .bio(profile.getBio())
                 .contactEmail(profile.getContactEmail())


### PR DESCRIPTION
## Description
Handles bug where username is null in Client getAllFreelancers

## Implementation
- Added `username` in fromEntity

## Response
![image](https://github.com/user-attachments/assets/5f2129ee-b000-4548-94b8-6f09121d3436)
