### PR TITLE
feat: #439 Made UI for editing a comment post

### DIFF
--- a/quolance-ui/src/api/blog-api.ts
+++ b/quolance-ui/src/api/blog-api.ts
@@ -106,7 +106,6 @@ export interface CommentRequestDto {
   content: string;
 }
 
-
 export const useGetCommentsByPostId = (postId: string, pagination: PaginationParams, options?: {
     onSuccess?: (data: PagedResponse<CommentResponseDto>) => void;
     onError?: (error: HttpErrorResponse) => void;
@@ -148,6 +147,20 @@ export const useDeleteComment = (options?: {
   });
 };
 
+export const useUpdateComment = (options?: {
+  onSuccess?: (
+    data: void, 
+    variables: { commentId: string; content: string; blogPostId: string }
+  ) => void;
+  onError?: (error: HttpErrorResponse) => void;
+}) => {
+  return useMutation<void, HttpErrorResponse, { commentId: string; content: string; blogPostId: string }>({
+    mutationFn: async (commentData) => {
+      await httpClient.put(`/api/blog-comments/${commentData.commentId}`, { content: commentData.content });
+    },
+    ...options,
+  });
+};
 
 /* ---------- Blog Reactions ---------- */
 export interface ReactionResponseDto {

--- a/quolance-ui/src/api/blog-api.ts
+++ b/quolance-ui/src/api/blog-api.ts
@@ -13,6 +13,8 @@ export interface BlogPostUpdateDto {
   postId: string;
   title: string;
   content: string;
+  // tags: string[];
+  // files?: File[];
 }
 
 export const useCreateBlogPost = (options?: {
@@ -67,19 +69,18 @@ export const useGetAllBlogPosts = () => {
   });
 };
 
-
-// export const useUpdateBlogPost = (options?: {
-//   onSuccess?: (data: BlogPostViewType) => void;
-//   onError?: (error: HttpErrorResponse) => void;
-// }) => {
-//   return useMutation<BlogPostViewType, HttpErrorResponse, BlogPostUpdateDto>({
-//     mutationFn: async (postData) => {
-//       const response = await httpClient.put('/api/blog-posts/update', postData);
-//       return response.data;
-//     },
-//     ...options,
-//   });
-// };
+export const useUpdateBlogPost = (options?: {
+  onSuccess?: (data: BlogPostViewType) => void;
+  onError?: (error: HttpErrorResponse) => void;
+}) => {
+  return useMutation<BlogPostViewType, HttpErrorResponse, BlogPostUpdateDto>({
+    mutationFn: async (postData) => {
+      const response = await httpClient.put('/api/blog-posts/update', postData);
+      return response.data;
+    },
+    ...options,
+  });
+};
 
 export const useDeleteBlogPost = (options?: {
   onSuccess?: () => void;

--- a/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
@@ -27,15 +27,30 @@ import {
 ];
 
 interface CreatePostFormProps {
-  onSubmit: (postData: { title: string; content: string; userId: string | undefined; tags: string[]; files?: File[]  }) => void;
+  onSubmit: (postData: { 
+    id?: string; 
+    title: string; 
+    content: string; 
+    userId?: string; 
+    tags: string[]; 
+    files?: File[] 
+  }) => void;
   onClose: () => void;
+  initialData?: { 
+    id: string; 
+    title: string; 
+    content: string; 
+    tags?: string[]; 
+    imageUrls?: string[] 
+  };
+  isEditMode?: boolean;
 }
 
-const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) => {
+const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose, initialData, isEditMode }) => {
   const { user } = useAuthGuard({ middleware: 'auth' });
-  const [title, setTitle] = useState<string>('');
-  const [content, setContent] = useState<string>('');
-  const [tags, setTags] = useState<string[]>([]);
+  const [title, setTitle] = useState<string>(initialData?.title || '');
+  const [content, setContent] = useState<string>(initialData?.content || '');
+  const [tags, setTags] = useState<string[]>(initialData?.tags || []);
   const [error, setError] = useState('');
   const [files, setFiles] = useState<File[]>([]);
 
@@ -83,14 +98,21 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose }) =>
       return;
     }
 
-    console.log({ title, content, tags });
+    const postData = { 
+      id: initialData?.id,
+      title, 
+      content, 
+      userId: 
+      user.id, 
+      tags, 
+      files 
+    };
 
-    onSubmit({ title, content, userId: user?.id, tags, files });
-    setTitle('');
-    setContent('');
-    setFiles([]);
-    setTags([]);
-    setError('');
+    if (!isEditMode && user?.id) {
+      onSubmit({ ...postData, userId: user.id });
+    } else {
+      onSubmit(postData);
+    }
     onClose();
   };
 

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -24,6 +24,8 @@ import { Button } from "../button";
 import { IoSendSharp } from 'react-icons/io5'
 import { MdExpandMore, MdExpandLess } from 'react-icons/md'
 import { useQueryClient } from "@tanstack/react-query";
+import CreatePostModal from "./CreatePostModal";
+import CreatePostForm from "./CreatePostForm";
 
 interface ReactionState {
   [key: string]: { count: number; userReacted: boolean };
@@ -39,9 +41,16 @@ interface PostCardProps {
   imageUrls?: string[];
   openUserSummaryPostId: string | null;
   setOpenUserSummaryPostId: (open: string | null) => void;
+  onSubmit: (postData: { 
+    id?: string; 
+    title: string; 
+    content: string; 
+    tags: string[]; 
+    files?: File[] 
+  }) => void;
 }
 
-const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dateCreated, tags, imageUrls = [], openUserSummaryPostId, setOpenUserSummaryPostId }) => {
+const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dateCreated, tags, imageUrls = [], openUserSummaryPostId, setOpenUserSummaryPostId, onSubmit }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [showComments, setShowComments] = useState(false);
   const [newComment, setNewComment] = useState<string>("");
@@ -49,6 +58,8 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
   const [showFullScreen, setShowFullScreen] = useState<boolean>(false);
   const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
   const [allLoadedComments, setAllLoadedComments] = useState<CommentResponseDto[]>([]);
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [editingPost, setEditingPost] = useState<PostCardProps | null>(null);
 
   const [userSummaryPosition, setUserSummaryPosition] = useState<{ x: number; y: number } | null>(null);
   const [pagination, setPagination] = useState<PaginationParams>({page: 0, size: 5});
@@ -224,7 +235,21 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
     }
   };
 
-  const handleEdit = () => {console.log("Edit post")};
+  const handleEdit = () => {
+    setEditingPost({
+      id,
+      title,
+      content,
+      tags,
+      imageUrls,
+      authorName,
+      dateCreated,
+      openUserSummaryPostId,
+      setOpenUserSummaryPostId,
+      onSubmit,
+    });
+    setIsEditing(true);
+  };
   const handleReport = () => {console.log("Report post")};
 
   const handleLoadMoreComments = () => {
@@ -330,6 +355,19 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
                 )
               }
               </div>
+            )}
+            {isEditing && editingPost && (
+              <CreatePostModal open={isEditing} onClose={() => setIsEditing(false)}>
+                <CreatePostForm
+                  initialData={editingPost}
+                  isEditMode={true}
+                  onSubmit={(postData) => {
+                    onSubmit(postData);
+                    setIsEditing(false);
+                  }}
+                  onClose={() => setIsEditing(false)}
+                />
+              </CreatePostModal>
             )}
           </div>
           

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -549,6 +549,7 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
               {allLoadedComments.map((comment) => (
                 <CommentCard
                   key={comment.commentId}
+                  blogPostId={id}
                   commentId={comment.commentId}
                   authorName={comment.username}
                   content={comment.content}


### PR DESCRIPTION
# Make UI for editing a blog post and blog comment

## **Summary**
This PR introduces editing capabilities for both blog posts and comments, allowing users to seamlessly update their content. The editing functionality is now integrated into the UI with real-time updates.

---

## **Key Changes**

### **Blog Post Editing**
- **Edit Blog Posts Directly from the UI**
  - Users can now click **"Edit"** on their own posts, opening a modal with prefilled data.
  - Implemented **"Save" and "Cancel"** options to either update or discard changes.

- **Updated `CreatePostForm.tsx` to Support Editing**
  - Added `initialData` prop to populate fields when editing.
  - Ensured the form differentiates between **creating a new post and updating an existing one**.
  - Introduced conditional logic to send a **PUT request for updates** instead of a POST.

- **Enhanced `BlogContainer.tsx` to Handle Updates**
  - Integrated `useUpdateBlogPost` API hook for updating blog posts.
  - Implemented **query invalidation** to refresh post data after edits.


### **Comment Editing**
- **Inline Comment Editing Now Supported**
  - Users can now edit their own comments without opening a separate modal.
  - Clicking "Edit" replaces the comment text with a textarea for inline modifications.

- **Updated `CommentCard.tsx`**
  - Introduced `isEditing` state to toggle between edit mode and read mode.
  - Added "Save" and "Cancel" options for better user control.

- **Implemented `useUpdateComment` API Hook**
  - Created a PUT request mutation for updating comment content.
  - Modified `handleSave` to ensure instant UI updates via state instead of refetching.

---

## **Future Enhancements**
- Add "Edit History" tracking for transparency in content modifications.

---

## **Screenshots & Demos**
- Blog Post edit
![image](https://github.com/user-attachments/assets/acf570c3-1066-4882-98c1-9d9fae14e4e7)

- Blog Comment edit
![image](https://github.com/user-attachments/assets/7094454c-8984-4caf-8211-df3db4271b03)

---

Closes #439