### PR TITLE
bugfix: #362 Fix Log Errors in Exception Tests for Services

### DIFF
--- a/quolance-api/src/test/resources/logback-test.xml
+++ b/quolance-api/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>WARN</level>
+        </filter>
+    </appender>
+
+    <logger name="com.quolance.quolance_api.services" level="OFF" />
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Description
Fixes all the warning logs that appear when running tests that use Exceptions in Services.

## Implementation
- Added `logback-test-xml` which suppresses logs when running tests for Services.

## Example
![image](https://github.com/user-attachments/assets/68f3edb8-9c9e-4f88-b326-6a22f97e650a)

## Log Now
![image](https://github.com/user-attachments/assets/48b76139-a2d3-4002-9094-b6162f007240)

