### PR TITLE
bugfix: #477 fixed profile pictures' shape for both blog posts and comments

### DIFF
--- a/quolance-ui/src/components/ui/blog/CommentCard.tsx
+++ b/quolance-ui/src/components/ui/blog/CommentCard.tsx
@@ -57,7 +57,7 @@ const CommentCard: React.FC<CommentCardProps> = ({
             src={authorProfile?.profileImageUrl || icon}
             width={24}
             height={24}
-            className="rounded-full object-cover"
+            className="w-8 h-8 rounded-full object-cover"
           />
           <p className="text-sm font-semibold text-gray-800 font-sans">{authorName}</p>
           <span className="text-xs text-gray-500">

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -265,7 +265,7 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
             src={authorProfile?.profileImageUrl || icon}
             width={56}
             height={56}
-            className="rounded-full object-cover cursor-pointer"
+            className="w-14 h-14 rounded-full object-cover cursor-pointer"
             onClick={handleShowUserSummary}
           />
           <button

--- a/quolance-ui/src/components/ui/blog/UserSummary.tsx
+++ b/quolance-ui/src/components/ui/blog/UserSummary.tsx
@@ -25,7 +25,7 @@ const UserSummary: React.FC<{user: FreelancerProfileType}> = ({ user }) => {
                     src={user.profileImageUrl || FreelancerDefaultIcon}
                     width={100}
                     height={100}
-                    className="rounded-full object-cover"
+                    className="w-32 h-32 rounded-full object-cover"
                 />
             </div>
             <div className="mt-3 text-sm text-gray-800">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/09b69171-7f97-4a43-af36-9819276c2c18)
Closes #477 