### PR TITLE
bugfix: #495 Fixed bug where clients could not create blog posts

### DIFF
--- a/quolance-ui/src/components/ui/blog/BlogContainer.tsx
+++ b/quolance-ui/src/components/ui/blog/BlogContainer.tsx
@@ -140,9 +140,9 @@ const BlogContainer: React.FC = () => {
                                     <Loading />
                                 ) : user ? (
                                     <CreatePostForm
-                                        onSubmit={({ userId, ...postData }) => handleFormSubmit(postData)}
+                                        onSubmit={(postData) => handleFormSubmit({ ...postData, userId: user.id })}
                                         onClose={() => setIsModalOpen(false)}
-                                    />
+                                        />
                                 ) : (
                                     <div className="flex justify-center items-center h-full">
                                         <div className="p-4 text-center">


### PR DESCRIPTION
## Clients and Freelancers can now post as intended!
There was just a small problem in ```CreatePostForm``` related to how we were destructuring ```user id``` when passing its data into ```handleFormSubmit()```.

![image](https://github.com/user-attachments/assets/294a4be4-5d6f-4edc-8bd8-9f4e4e3641fb)

closes #495  