### PR TITLE
feat: #522 Made Password Validation Consistent Across All User Flows

### DIFF
--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/components/update-password-and-role-form.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/components/update-password-and-role-form.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/util/utils';
 import { useAuthGuard } from '@/api/auth-api';
 
 import PasswordRequirements from '@/app/(without-main-layout)/auth/register/components/PasswordRequirement';
+import PasswordStrengthBar from '../setting/components/PasswordStrengthBar';
 
 type UserAuthFormProps = React.HTMLAttributes<HTMLDivElement>;
 
@@ -126,6 +127,7 @@ export function UpdatePendingUserForm({
             disabled={isLoading}
             {...register('password')}
           />
+          {password?.length > 0 && <PasswordStrengthBar password={password} />}
           <PasswordRequirements password={password} />
           {formState.errors.password && (
             <small className='text-red-600'>

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/components/update-password-and-role-form.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/components/update-password-and-role-form.tsx
@@ -19,6 +19,8 @@ import { HttpErrorResponse } from '@/models/http/HttpErrorResponse';
 import { cn } from '@/util/utils';
 import { useAuthGuard } from '@/api/auth-api';
 
+import PasswordRequirements from '@/app/(without-main-layout)/auth/register/components/PasswordRequirement';
+
 type UserAuthFormProps = React.HTMLAttributes<HTMLDivElement>;
 
 // Define schema for form validation using Zod
@@ -78,10 +80,12 @@ export function UpdatePendingUserForm({
       });
   }
 
-  const { register, handleSubmit, formState } = useForm<Schema>({
+  const { register, handleSubmit, formState, watch } = useForm<Schema>({
     resolver: zodResolver(updateSchema),
     reValidateMode: 'onSubmit',
   });
+
+  const password = watch('password');
 
   return (
     <div className={cn('grid gap-6', className)} {...props}>
@@ -122,6 +126,7 @@ export function UpdatePendingUserForm({
             disabled={isLoading}
             {...register('password')}
           />
+          <PasswordRequirements password={password} />
           {formState.errors.password && (
             <small className='text-red-600'>
               {formState.errors.password.message}

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/ChangePassword.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/setting/components/ChangePassword.tsx
@@ -15,6 +15,8 @@ import { showToast } from '@/util/context/ToastProvider';
 
 import PasswordStrengthBar from './PasswordStrengthBar';
 
+import PasswordRequirements from '@/app/(without-main-layout)/auth/register/components/PasswordRequirement';
+
 const changePasswordSchema = z
   .object({
     oldPassword: z.string().min(1, 'Current password is required'),
@@ -132,6 +134,7 @@ export default function ChangePassword() {
             </small>
           )}
           {password.length >= 1 && <PasswordStrengthBar password={password} />}
+          {password.length >= 1 && <PasswordRequirements password={password} />}
         </div>
 
         <div className='col-span-full'>

--- a/quolance-ui/src/app/(without-main-layout)/auth/register/components/register-form.tsx
+++ b/quolance-ui/src/app/(without-main-layout)/auth/register/components/register-form.tsx
@@ -20,6 +20,7 @@ import {
   SocialAuthLogins,
 } from '@/app/(without-main-layout)/auth/shared/auth-components';
 import PasswordRequirements from './PasswordRequirement';
+import PasswordStrengthBar from '@/app/(with-main-layout)/(authenticated-pages)/setting/components/PasswordStrengthBar';
 
 
 type UserAuthFormProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -160,6 +161,7 @@ export function UserRegisterForm({
               data-test='password-input'
             />
 
+            {password?.length > 0 && <PasswordStrengthBar password={password} />}
             <PasswordRequirements password={password} />
 
             <FormInput


### PR DESCRIPTION
# Make Password Validation Consistent Across All User Flows

## Summary

This PR unifies and enhances the password validation experience across the application. The validation logic and UI are now consistent in the following flows:

- Regular registration
- Google OAuth onboarding (temporary password update)
- Password change from the user profile settings

## Key Changes

### Password Requirement Checklist

- Reused `PasswordRequirements` component in all password entry forms:
  - Applied to:
    - `UpdatePendingUserForm.tsx` (OAuth temporary password update)
    - `ChangePassword.tsx` (Profile > Change Password)

### Password Strength Indicator

- Reused `PasswordStrengthBar` component originally used for profile setting:
  - Applied in:
    - Registration form
    - Google OAuth password update

### Validation Consistency

- Unified password mismatch and invalid pattern messages

## Screenshots

Set Password upon registering through Google oAuth
![image](https://github.com/user-attachments/assets/4cf5fe85-0f1a-4f16-a779-6aeb69cb713f)
![image](https://github.com/user-attachments/assets/c693029d-ce71-46fc-8b27-ce1407267bb4)

Change Password through Settings
![image](https://github.com/user-attachments/assets/4c4195f3-64d0-41be-a594-dedf9c24d14d)
![image](https://github.com/user-attachments/assets/04ff5087-49dc-4d85-9b4b-10df66d4360f)

Set Password upon regular registration
![image](https://github.com/user-attachments/assets/a25abcb2-310e-48ab-a49a-212cba0c8619)
![image](https://github.com/user-attachments/assets/3c454023-c352-45a3-81b3-090f9dd65565)

Closes #522