### PR TITLE
feat: #527 Updated post ordering

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogPostResponseDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogPostResponseDto.java
@@ -24,6 +24,7 @@ public class BlogPostResponseDto {
     private String content;
     private String authorName;
     private LocalDateTime dateCreated;
+    private LocalDateTime lastModified;
     private List<BlogCommentDto> comments;
     private Set<String> tags;
     private UUID userId;
@@ -38,7 +39,8 @@ public class BlogPostResponseDto {
         response.setTitle(blogPost.getTitle());
         response.setContent(blogPost.getContent());
         response.setAuthorName(blogPost.getUser().getUsername());
-        response.setDateCreated(blogPost.getCreationDate());
+        response.setDateCreated(blogPost.getDateCreated());
+        response.setLastModified(blogPost.getLastModified());
         response.setTags(blogPost.getTags() != null
                 ? blogPost.getTags().stream()
                 .map(Enum::name)

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogPostResponseDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogPostResponseDto.java
@@ -39,8 +39,8 @@ public class BlogPostResponseDto {
         response.setTitle(blogPost.getTitle());
         response.setContent(blogPost.getContent());
         response.setAuthorName(blogPost.getUser().getUsername());
-        response.setDateCreated(blogPost.getDateCreated());
-        response.setLastModified(blogPost.getLastModified());
+        response.setDateCreated(blogPost.getCreationDate());
+        response.setLastModified(blogPost.getLastModifiedDate());
         response.setTags(blogPost.getTags() != null
                 ? blogPost.getTags().stream()
                 .map(Enum::name)

--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/blog/BlogPost.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/blog/BlogPost.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
-import java.time.LocalDateTime;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,12 +38,6 @@ public class BlogPost extends AbstractEntity {
 
     @Column(nullable = false)
     private boolean isResolved;
-
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime dateCreated;
-
-    @Column(nullable = false)
-    private LocalDateTime lastModified;
 
     @OneToMany(mappedBy = "blogPost", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BlogComment> blogComments = new ArrayList<>();

--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/blog/BlogPost.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/blog/BlogPost.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import java.time.LocalDateTime;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +39,12 @@ public class BlogPost extends AbstractEntity {
 
     @Column(nullable = false)
     private boolean isResolved;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime dateCreated;
+
+    @Column(nullable = false)
+    private LocalDateTime lastModified;
 
     @OneToMany(mappedBy = "blogPost", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BlogComment> blogComments = new ArrayList<>();

--- a/quolance-api/src/main/java/com/quolance/quolance_api/repositories/blog/BlogPostRepository.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/repositories/blog/BlogPostRepository.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public interface BlogPostRepository extends JpaRepository<BlogPost, UUID> {
     List<BlogPost> findByUserId(UUID userId);
 
-    Page<BlogPost> findAll(Pageable pageable);
+    Page<BlogPost> findAllByOrderByLastModifiedDesc(Pageable pageable);
 
     @Query("SELECT b FROM BlogPost b " +
             "JOIN b.tags t " +

--- a/quolance-api/src/main/java/com/quolance/quolance_api/repositories/blog/BlogPostRepository.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/repositories/blog/BlogPostRepository.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public interface BlogPostRepository extends JpaRepository<BlogPost, UUID> {
     List<BlogPost> findByUserId(UUID userId);
 
-    Page<BlogPost> findAllByOrderByLastModifiedDesc(Pageable pageable);
+    Page<BlogPost> findAllByOrderByLastModifiedDateDesc(Pageable pageable);
 
     @Query("SELECT b FROM BlogPost b " +
             "JOIN b.tags t " +

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
@@ -64,6 +64,8 @@ public class BlogPostServiceImpl implements BlogPostService {
                 .user(author)
                 .tags(request.getTags() != null ? Set.copyOf(request.getTags()) : Set.of())
                 .images(blogImages)  // Associate the BlogImage entities
+                .dateCreated(LocalDateTime.now())
+                .lastModified(LocalDateTime.now())
                 .build();
 
         // Associate the blog post with each BlogImage
@@ -133,6 +135,7 @@ public class BlogPostServiceImpl implements BlogPostService {
             blogPost.setContent(updateRequest.getContent());
         if (updateRequest.getTitle() != null)
             blogPost.setTitle(updateRequest.getTitle());
+        blogPost.setLastModified(LocalDateTime.now());
         return blogPost;
     }
 
@@ -200,8 +203,10 @@ public class BlogPostServiceImpl implements BlogPostService {
 
     @Override
     public Page<BlogPostResponseDto> getPaginatedBlogPosts(Pageable pageable) {
-        return blogPostRepository.findAll(pageable).map(BlogPostResponseDto::fromEntity);
+        return blogPostRepository.findAllByOrderByLastModifiedDesc(pageable)
+                .map(BlogPostResponseDto::fromEntity);
     }
+
     @Override
     public Page<BlogPostResponseDto> getFilteredPosts(BlogFilterRequestDto filterDto, Pageable pageable) {
         LocalDateTime startDate = filterDto.getCreationDate();

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
@@ -17,7 +17,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,16 +39,13 @@ public class BlogPostServiceImpl implements BlogPostService {
         log.info("Creating a new blog post for user: {}", author.getId());
         List<BlogImage> blogImages = new ArrayList<>();
 
-        // Step 1: Upload images and create BlogImage entities
         if (request.getImages() != null) {
             for (MultipartFile image : request.getImages()) {
                 log.debug("Processing image: {}", image.getOriginalFilename());
                 System.out.println("Received file: " + image.getOriginalFilename());
-                // Upload to Cloudinary or local storage and get the path/URL
                 Map<String, Object> uploadResult = fileService.uploadFile(image, author);
-                String imagePath = uploadResult.get("secure_url").toString();  // Store the Cloudinary URL
+                String imagePath = uploadResult.get("secure_url").toString();
 
-                // Create BlogImage entity and associate it with the post
                 BlogImage blogImage = BlogImage.builder()
                         .imagePath(imagePath)
                         .build();
@@ -57,23 +53,20 @@ public class BlogPostServiceImpl implements BlogPostService {
             }
         }
 
-        // Step 2: Convert DTO to BlogPost entity
         BlogPost blogPost = BlogPost.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .user(author)
                 .tags(request.getTags() != null ? Set.copyOf(request.getTags()) : Set.of())
-                .images(blogImages)  // Associate the BlogImage entities
-                .dateCreated(LocalDateTime.now())
-                .lastModified(LocalDateTime.now())
+                .images(blogImages)
+//                .dateCreated(LocalDateTime.now())
+//                .lastModified(LocalDateTime.now())
                 .build();
 
-        // Associate the blog post with each BlogImage
         for (BlogImage blogImage : blogImages) {
             blogImage.setBlogPost(blogPost);
         }
 
-        // Step 3: Save the blog post
         BlogPost savedBlogPost = blogPostRepository.save(blogPost);
         log.info("Blog post created successfully with ID: {}", savedBlogPost.getId());
         return BlogPostResponseDto.fromEntity(savedBlogPost);
@@ -135,7 +128,7 @@ public class BlogPostServiceImpl implements BlogPostService {
             blogPost.setContent(updateRequest.getContent());
         if (updateRequest.getTitle() != null)
             blogPost.setTitle(updateRequest.getTitle());
-        blogPost.setLastModified(LocalDateTime.now());
+//        blogPost.setLastModified(LocalDateTime.now());
         return blogPost;
     }
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
@@ -196,7 +196,7 @@ public class BlogPostServiceImpl implements BlogPostService {
 
     @Override
     public Page<BlogPostResponseDto> getPaginatedBlogPosts(Pageable pageable) {
-        return blogPostRepository.findAllByOrderByLastModifiedDesc(pageable)
+        return blogPostRepository.findAllByOrderByLastModifiedDateDesc(pageable)
                 .map(BlogPostResponseDto::fromEntity);
     }
 

--- a/quolance-api/src/test/java/com/quolance/quolance_api/helpers/integration/EntityCreationHelper.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/helpers/integration/EntityCreationHelper.java
@@ -108,6 +108,10 @@ public class EntityCreationHelper {
         BlogPost blogPost = new BlogPost();
         blogPost.setContent("This is a test blog post.");
         blogPost.setUser(user);
+        blogPost.setDateCreated(LocalDateTime.now());
+        blogPost.setLastModified(LocalDateTime.now());
+        blogPost.setReported(false);
+        blogPost.setResolved(false);
         return blogPost;
     }
 
@@ -117,7 +121,10 @@ public class EntityCreationHelper {
         blogPost.setContent(content);
         blogPost.setUser(user);
         blogPost.setTags(Set.copyOf(tags));
-        blogPost.setCreationDate(creationDate);
+        blogPost.setDateCreated(creationDate);
+        blogPost.setLastModified(creationDate);
+        blogPost.setReported(false);
+        blogPost.setResolved(false);
         return blogPost;
     }
 
@@ -126,6 +133,10 @@ public class EntityCreationHelper {
         blogPost.setTitle("Blog Post with Images");
         blogPost.setContent("This is a test blog post with images.");
         blogPost.setUser(user);
+        blogPost.setDateCreated(LocalDateTime.now());
+        blogPost.setLastModified(LocalDateTime.now());
+        blogPost.setReported(false);
+        blogPost.setResolved(false);
 
         // Create dummy BlogImage entities
         BlogImage image1 = BlogImage.builder().imagePath("https://example.com/image1.jpg").build();

--- a/quolance-api/src/test/java/com/quolance/quolance_api/helpers/integration/EntityCreationHelper.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/helpers/integration/EntityCreationHelper.java
@@ -108,8 +108,8 @@ public class EntityCreationHelper {
         BlogPost blogPost = new BlogPost();
         blogPost.setContent("This is a test blog post.");
         blogPost.setUser(user);
-        blogPost.setDateCreated(LocalDateTime.now());
-        blogPost.setLastModified(LocalDateTime.now());
+//        blogPost.setDateCreated(LocalDateTime.now());
+//        blogPost.setLastModified(LocalDateTime.now());
         blogPost.setReported(false);
         blogPost.setResolved(false);
         return blogPost;
@@ -121,8 +121,8 @@ public class EntityCreationHelper {
         blogPost.setContent(content);
         blogPost.setUser(user);
         blogPost.setTags(Set.copyOf(tags));
-        blogPost.setDateCreated(creationDate);
-        blogPost.setLastModified(creationDate);
+//        blogPost.setDateCreated(creationDate);
+//        blogPost.setLastModified(creationDate);
         blogPost.setReported(false);
         blogPost.setResolved(false);
         return blogPost;
@@ -133,8 +133,8 @@ public class EntityCreationHelper {
         blogPost.setTitle("Blog Post with Images");
         blogPost.setContent("This is a test blog post with images.");
         blogPost.setUser(user);
-        blogPost.setDateCreated(LocalDateTime.now());
-        blogPost.setLastModified(LocalDateTime.now());
+//        blogPost.setDateCreated(LocalDateTime.now());
+//        blogPost.setLastModified(LocalDateTime.now());
         blogPost.setReported(false);
         blogPost.setResolved(false);
 


### PR DESCRIPTION
## Fix return order of blog posts

### Summary

This PR enhances the blog post functionality. Blog posts are now sorted by their most recent updates rather than their creation date, allowing the system to display the most recently modified content first.

### Key Changes

#### Post Sorting Behavior
- Changed sorting logic in the `getPaginatedBlogPosts` method to order by `lastModified` in descending order.
- Replaced previous behavior of sorting by `creationDate` ascending.

#### DTO & Service Updates
- Updated `BlogPostResponseDto` to include the `lastModified` field.

#### Testing
- Ensured `dateCreated`, `lastModified`, `isReported`, and `isResolved` are set when creating BlogPost test entities
- Fixes failing integration tests due to NOT NULL constraint violations


Closes #527
