### PR TITLE
bugfix: #551 Fixed Blog posts text appears compressed on mobile devices

### DIFF
--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -391,14 +391,20 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
         </div>
       </div>
   
-      <div className="flex justify-between mt-2 gap-4">
+      <div className="flex flex-col md:flex-row md:items-start gap-6 mt-4">
         {/* Title + Content */}
-        <div className="flex-1">
-          <h3 className="text-xl font-semibold text-gray-800 my-3">{title}</h3>
-          <div className={`mt-1 ${!isExpanded ? "line-clamp-6 md:line-clamp-10" : ""}`}>
-            <p className="text-gray-700">{content}</p>
-          </div>
-  
+        <div className="flex-1 mt-2 md:mt-0">
+          <h3 className="text-xl md:text-2xl font-semibold text-gray-800 mb-3">{title}</h3>
+          {!isExpanded ? (
+            <div className="mt-1 line-clamp-6 md:line-clamp-10">
+              <p className="text-gray-700">{content}</p>
+            </div>
+          ) : (
+            <div className="mt-1">
+              <p className="text-gray-700">{content}</p>
+            </div>
+          )}
+
           {content.length > 800 && (
             <button
               onClick={toggleExpand}
@@ -413,7 +419,7 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
   
         {/* Image stack */}
         {imageUrls.length > 0 && (
-          <div className="relative w-[200px] h-[200px] mt-3 shrink-0">
+          <div className="relative w-full md:w-[200px] h-[200px] mb-2 md:mb-0 shrink-0">
             {imageUrls.slice(0, 3).map((url, index) => (
               <div
                 key={index}


### PR DESCRIPTION
# Fix Blog Post Layout Responsiveness

## Summary

This PR improves the blog post card layout on smaller screens by adjusting flex behaviour, ensuring a cleaner and more readable stacked layout on mobile while preserving the side-by-side layout on larger screens.

## Key Changes

- Switched to responsive flex behaviour (`flex-col` on smaller screens, `flex-row` on larger screens)
- Improved spacing between text and image

## Screenshots

Larger screen layout
![image](https://github.com/user-attachments/assets/1a13d726-0c15-48d9-8315-9f17767d7566)

Smaller screen layout
![image](https://github.com/user-attachments/assets/8da0826b-58ac-41d2-820e-db6c9aa3dd3b)

Closes #551
