### PR TITLE
feat: #555 Simplified OAuth Google authentication process

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/configs/ApplicationProperties.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/configs/ApplicationProperties.java
@@ -20,4 +20,5 @@ public class ApplicationProperties {
     private String adminUserEmail;
     private String adminUserPassword;
     private String verifyEmailUrl;
+    private String resetPasswordUrl;
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/entities/User.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/entities/User.java
@@ -144,7 +144,6 @@ public class User extends AbstractEntity implements UserDetails {
             }
         }
         this.verified = true;
-        this.role = Role.PENDING;
     }
 
     /**

--- a/quolance-api/src/main/java/com/quolance/quolance_api/jobs/SendGoogleWelcomeEmailJob.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/jobs/SendGoogleWelcomeEmailJob.java
@@ -1,0 +1,23 @@
+package com.quolance.quolance_api.jobs;
+
+import com.quolance.quolance_api.jobs.handlers.SendGoogleWelcomeEmailJobHandler;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jobrunr.jobs.lambdas.JobRequest;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SendGoogleWelcomeEmailJob implements JobRequest {
+    private UUID userId;
+
+    @Override
+    public Class<? extends JobRequestHandler> getJobRequestHandler() {
+        return SendGoogleWelcomeEmailJobHandler.class;
+    }
+
+}

--- a/quolance-api/src/main/java/com/quolance/quolance_api/jobs/handlers/SendGoogleWelcomeEmailJobHandler.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/jobs/handlers/SendGoogleWelcomeEmailJobHandler.java
@@ -1,0 +1,57 @@
+package com.quolance.quolance_api.jobs.handlers;
+
+import com.quolance.quolance_api.configs.ApplicationProperties;
+import com.quolance.quolance_api.entities.User;
+import com.quolance.quolance_api.jobs.SendGoogleWelcomeEmailJob;
+import com.quolance.quolance_api.services.auth.EmailService;
+import com.quolance.quolance_api.services.entity_services.UserService;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SendGoogleWelcomeEmailJobHandler implements JobRequestHandler<SendGoogleWelcomeEmailJob> {
+    private final UserService userService;
+    private final SpringTemplateEngine templateEngine;
+    private final EmailService emailService;
+    private final ApplicationProperties applicationProperties;
+
+    @Override
+    @Transactional
+    public void run(SendGoogleWelcomeEmailJob sendWelcomeEmailJob) throws Exception {
+        UUID userId = sendWelcomeEmailJob.getUserId();
+
+        Thread.sleep(5000);
+
+        User user = userService.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        try {
+            sendGoogleWelcomeEmail(user);
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    private void sendGoogleWelcomeEmail(User user) throws MessagingException {
+        Context thymeleafContext = new Context();
+        thymeleafContext.setVariable("user", user);
+        thymeleafContext.setVariable("applicationName", applicationProperties.getApplicationName());
+        thymeleafContext.setVariable("resetPasswordUrl", applicationProperties.getResetPasswordUrl());
+
+        String htmlBody = templateEngine.process("welcome-email-google", thymeleafContext);
+        String subject = "Welcome to Quolance!";
+
+        emailService.sendHtmlMessage(List.of(user.getEmail()), subject, htmlBody);
+    }
+}

--- a/quolance-api/src/main/resources/application.yml
+++ b/quolance-api/src/main/resources/application.yml
@@ -6,6 +6,8 @@ app:
   login-page-url: "${app.ui-url}/auth/login"
   login-success-url: "${app.ui-url}/auth/login-success"
   verify-email-url: "${app.ui-url}/auth/verify-email"
+  reset-password-url: "${app.ui-url}/auth/reset-password"
+
   admin:
     email: ${ADMIN_EMAIL}
     password: ${ADMIN_PASSWORD}

--- a/quolance-api/src/main/resources/mail-templates/welcome-email-google.html
+++ b/quolance-api/src/main/resources/mail-templates/welcome-email-google.html
@@ -2,9 +2,9 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
-          name="viewport">
-    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>Welcome to Quolance</title>
     <style>
         * {
@@ -23,21 +23,21 @@
             max-width: 600px;
             margin: 0 auto;
             background-color: white;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            border-radius: 10px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
             padding: 40px;
         }
 
-        .quolance {
-            font-size: 24px;
+        .brand {
+            font-size: 28px;
             font-weight: 700;
-            color: #1a1a1a;
+            color: #3B6BFF;
             margin-bottom: 30px;
             text-decoration: none;
         }
 
         h1 {
-            font-size: 24px;
+            font-size: 26px;
             color: #1a1a1a;
             margin-bottom: 20px;
         }
@@ -47,18 +47,6 @@
             font-size: 16px;
             line-height: 1.6;
             margin-bottom: 16px;
-        }
-
-        .verification-code {
-            background-color: #f8f9fa;
-            padding: 16px;
-            border-radius: 6px;
-            font-size: 24px;
-            font-weight: bold;
-            color: #1a1a1a;
-            text-align: center;
-            margin: 24px 0;
-            letter-spacing: 2px;
         }
 
         .button {
@@ -77,32 +65,35 @@
             padding-top: 20px;
             border-top: 1px solid #eee;
             font-size: 14px;
-            color: #666;
+            color: #888;
         }
     </style>
 </head>
 <body>
 <div class="email-container">
-    <div class="quolance">
-        Quolance
-    </div>
+    <div class="brand">Quolance</div>
 
-    <h1 th:text="'Welcome to Quolance, ' + ${user.firstName} + '!'"></h1>
+    <h1 th:text="'Welcome to Quolance, ' + ${user.firstName} + '!'">Welcome to Quolance!</h1>
 
-    <p>We're excited to have you join our community of talented freelancers and clients. To get started, please
-        verify your email address.</p>
+    <p>
+        We're thrilled to have you join our community of talented freelancers and ambitious clients. Whether you're here to
+        find incredible opportunities or connect with the right talent, you're in the right place.
+    </p>
 
-    <div class="verification-code" th:text="${verificationCode}"></div>
+    <p>
+        If you ever want to access the platform using your email and a password, you can easily do so by resetting your password.
+    </p>
 
-    <p>Enter this verification code on the site to complete your account creation. This code will expire in 10
-        minutes.</p>
+    <p>
+        Click below to set a new password at any time:
+    </p>
 
-    <a class="button" th:href="@{${verificationLink}+ '/'+${user.getEmail()}}" target="_blank">
-        Verify Email Address
+    <a class="button" th:href="@{${resetPasswordUrl}}" target="_blank">
+        Reset Your Password
     </a>
-
-    <p style="font-size: 14px; color: #666;">If you didn't create an account with Quolance, please ignore this
-        email.</p>
+    <p>
+        We're here to support you every step of the way. If you have any questions or feedback, feel free to reach out.
+    </p>
 
     <div class="footer">
         Need help? Contact our support team at <a href="mailto:support@quolance.com">support@quolance.com</a><br/>

--- a/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/layout.tsx
+++ b/quolance-ui/src/app/(with-main-layout)/(authenticated-pages)/layout.tsx
@@ -3,10 +3,7 @@
 import Loading from '@/components/ui/loading/loading';
 import VerificationNotice from '@/components/verify-account';
 
-import { useAuthGuard } from '@/api/auth-api';
-import { Role } from '@/models/user/UserResponse';
-
-import PendingUserForm from './components/pending-user-form';
+import {useAuthGuard} from '@/api/auth-api';
 
 export default function DashboardLayout({
   children,
@@ -19,7 +16,6 @@ export default function DashboardLayout({
 
   if (!user?.verified) return <VerificationNotice logout={logout} />;
 
-  if (user?.role === Role.PENDING) return <PendingUserForm user={user} />;
 
   return <>{children}</>;
 }

--- a/quolance-ui/src/app/(without-main-layout)/auth/register/components/register-form.tsx
+++ b/quolance-ui/src/app/(without-main-layout)/auth/register/components/register-form.tsx
@@ -2,11 +2,11 @@
 
 import {zodResolver} from '@hookform/resolvers/zod';
 import Link from 'next/link';
-import React, { useRef, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import { z } from 'zod';
-import { motion } from 'framer-motion';
+import React, {useEffect, useRef} from 'react';
+import {useForm} from 'react-hook-form';
+import {toast} from 'sonner';
+import {z} from 'zod';
+import {motion} from 'framer-motion';
 
 import httpClient from '@/lib/httpClient';
 import ErrorFeedback from '@/components/error-feedback';
@@ -160,7 +160,7 @@ export function UserRegisterForm({
         </motion.div>
         
         <motion.div variants={itemVariants}>
-          <SocialAuthLogins isLoading={isLoading} />
+          <SocialAuthLogins isLoading={isLoading} userRole={userRole} />
         </motion.div>
         
         <motion.form variants={itemVariants} onSubmit={handleSubmit(onSubmit)} className="space-y-5">

--- a/quolance-ui/src/app/(without-main-layout)/auth/shared/auth-components.tsx
+++ b/quolance-ui/src/app/(without-main-layout)/auth/shared/auth-components.tsx
@@ -1,20 +1,20 @@
 'use client';
 
 import Link from 'next/link';
-import { UseFormRegister } from 'react-hook-form';
-import { FaGithub, FaGoogle } from 'react-icons/fa';
-import { cn } from '@/util/utils';
+import {UseFormRegister} from 'react-hook-form';
+import {FaGoogle} from 'react-icons/fa';
+import {cn} from '@/util/utils';
 
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import {Button} from '@/components/ui/button';
+import {Input} from '@/components/ui/input';
+import {Label} from '@/components/ui/label';
 
 export const getProviderLoginUrl = (
-  provider: 'google' | 'facebook' | 'github' | 'okta'
+    provider: 'google',
+    role?: string
 ) => {
-  return process.env.NEXT_PUBLIC_BASE_URL + `/oauth2/authorization/${provider}`;
+  return `/api/set-role?role=${role}`;
 };
-
 interface FormInputProps {
   id: string;
   label: string;
@@ -56,22 +56,11 @@ export const FormInput = ({
   </div>
 );
 
-export const SocialAuthLogins = ({ isLoading }: { isLoading: boolean }) => (
+export const SocialAuthLogins = ({ isLoading, userRole }: { isLoading: boolean, userRole?: string }) => (
   <>
     <div className="flex flex-col gap-4 sm:flex-row">
-      {/* <Link href={getProviderLoginUrl('github')} className="w-full">
-        <Button
-          variant="outline"
-          type="button"
-          disabled={isLoading}
-          className="w-full"
-        >
-          <FaGithub className="mr-2 h-4 w-4" />
-          GitHub
-        </Button>
-      </Link> */}
 
-      <Link href={getProviderLoginUrl('google')} className="w-full">
+      <Link href={getProviderLoginUrl('google', userRole)} className="w-full">
         <Button
           variant="outline"
           type="button"

--- a/quolance-ui/src/app/api/set-role/route.ts
+++ b/quolance-ui/src/app/api/set-role/route.ts
@@ -1,0 +1,20 @@
+import {NextResponse} from 'next/server';
+import {cookies} from 'next/headers';
+
+export async function GET(request: Request) {
+    const { searchParams } = new URL(request.url);
+    const role = searchParams.get('role');
+
+    if (!role || (role !== 'CLIENT' && role !== 'FREELANCER')) {
+        return NextResponse.redirect(new URL('/auth/register', request.url));
+    }
+
+    console.log("User role: " + role)
+    cookies().set('selectedRole', role, {
+        path: '/',
+        httpOnly: false,
+        maxAge: 60 * 5,
+    });
+
+    return NextResponse.redirect(`${process.env.NEXT_PUBLIC_BASE_URL}/oauth2/authorization/google`);
+}


### PR DESCRIPTION
# In this PR:
- Modified the registration process for Google users to address comments made by users. 
- Removed the need for a PENDING role.

## Problem: 
- The previous process required users to check their email for a temporary password that was sent to them and then asked them to input it along with a new password, before being able to access the platform. 
- This was a complicated process that made google authentication harder than our custom registration.
- Users also had to choose twice what kind of account they want. Once in the registration page and once in the form where they put the new password.

## Fix:
- Stored the value of the desired role in a cookie and and set the role to the value of that cookie, instead of the previous default PENDING role.
- Added a new email that Google users receive instead of a temporary password email.
- Direct users to reset their password if they want to use both Google and their email/password to log in.

Closes #555 