### PR TITLE
feat: #560 added support for tags editing in blog posts

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogPostUpdateDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogPostUpdateDto.java
@@ -1,10 +1,12 @@
 package com.quolance.quolance_api.dtos.blog;
 
+import com.quolance.quolance_api.entities.enums.BlogTags;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -15,4 +17,5 @@ public class BlogPostUpdateDto {
     private UUID postId;
     private String title;
     private String content;
+    private Set<BlogTags> tags;
 }

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
@@ -123,12 +123,17 @@ public class BlogPostServiceImpl implements BlogPostService {
     }
 
     private BlogPost updateBlogPost(BlogPostUpdateDto updateRequest, BlogPost blogPost) {
-        log.debug("Updating blog post content and title");
-        if (updateRequest.getContent() != null)
+        log.debug("Updating blog post title, content, and tags");
+        if (updateRequest.getContent() != null) {
             blogPost.setContent(updateRequest.getContent());
-        if (updateRequest.getTitle() != null)
+        }
+        if (updateRequest.getTitle() != null) {
             blogPost.setTitle(updateRequest.getTitle());
-//        blogPost.setLastModified(LocalDateTime.now());
+        }
+        if (updateRequest.getTags() != null) {
+            blogPost.setTags(updateRequest.getTags());
+        }
+
         return blogPost;
     }
 

--- a/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/BlogControllerUnitTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/unit/controllers/BlogControllerUnitTest.java
@@ -154,7 +154,11 @@ class BlogControllersUnitTest {
         try (MockedStatic<SecurityUtil> securityUtil = mockStatic(SecurityUtil.class)) {
             UUID id = UUID.randomUUID();
             securityUtil.when(SecurityUtil::getAuthenticatedUser).thenReturn(mockUser);
-            BlogPostUpdateDto updateDto = new BlogPostUpdateDto(id, "Updated Title", "Updated Content");
+            BlogPostUpdateDto updateDto = new BlogPostUpdateDto();
+            updateDto.setPostId(id);
+            updateDto.setTitle("Updated_Title");
+            updateDto.setContent("Updated_Content");
+            updateDto.setTags(null);
             when(blogPostService.update(eq(updateDto), any(User.class))).thenReturn(blogPostResponse);
 
             ResponseEntity<BlogPostResponseDto> response = blogPostController.updateBlogPost(updateDto);

--- a/quolance-ui/src/api/blog-api.ts
+++ b/quolance-ui/src/api/blog-api.ts
@@ -11,8 +11,8 @@ export interface BlogPostUpdateDto {
   postId: string;
   title: string;
   content: string;
-  // tags: string[];
-  // files?: File[];
+  tags: string[];
+  existingImageUrls?: string[];
 }
 
 export const useCreateBlogPost = (options?: {

--- a/quolance-ui/src/components/ui/blog/BlogContainer.tsx
+++ b/quolance-ui/src/components/ui/blog/BlogContainer.tsx
@@ -90,11 +90,10 @@ const BlogContainer: React.FC = () => {
         try {
             if (postData.id) {
                 await updateBlogPost({
-                    postId: postData.id, 
+                    postId: postData.id,
                     title: postData.title, 
-                    content: postData.content
-                    // tags: postData.tags,
-                    // files: postData.files
+                    content: postData.content,
+                    tags: postData.tags
                 });
             } else {
                 await mutateBlogPosts({

--- a/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostForm.tsx
@@ -102,10 +102,9 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose, init
       id: initialData?.id,
       title, 
       content, 
-      userId: 
-      user.id, 
-      tags, 
-      files 
+      userId: user.id,
+      tags,
+      files
     };
 
     if (!isEditMode && user?.id) {
@@ -188,43 +187,47 @@ const CreatePostForm: React.FC<CreatePostFormProps> = ({ onSubmit, onClose, init
         )}
       </div>
 
-      {/* File Drop Area */}
-      <div
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
-        className="w-full p-6 border-dashed border-2 border-gray-300 rounded-md text-center bg-white"
-      >
-        <div className="text-2xl mb-2">📎</div>
-        <p className="text-gray-600 text-sm mb-1">Drag and drop images, or</p>
-        <label htmlFor="file-upload" className="cursor-pointer text-indigo-600 text-sm font-medium underline">
-          Select Files
-        </label>
-        <input
-          type="file"
-          accept="image/*"
-          multiple
-          onChange={handleFileChange}
-          className="hidden"
-          id="file-upload"
-        />
-      </div>
+      {!isEditMode &&(
+        <>
+          {/* File Drop Area */}
+          <div
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+            className="w-full p-6 border-dashed border-2 border-gray-300 rounded-md text-center bg-white"
+          >
+            <div className="text-2xl mb-2">📎</div>
+            <p className="text-gray-600 text-sm mb-1">Drag and drop images, or</p>
+            <label htmlFor="file-upload" className="cursor-pointer text-indigo-600 text-sm font-medium underline">
+              Select Files
+            </label>
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleFileChange}
+              className="hidden"
+              id="file-upload"
+            />
+          </div>
 
-      {/* Display selected files */}
-      {files.length > 0 && (
-        <ul className="mt-3 space-y-2 text-sm">
-          {files.map((file, index) => (
-            <li key={index} className="flex justify-between items-center border-b pb-1">
-              <span>{file.name}</span>
-              <button
-                type="button"
-                onClick={() => handleRemoveFile(index)}
-                className="text-red-500 hover:underline text-xs"
-              >
-                Remove
-              </button>
-            </li>
-          ))}
-        </ul>
+          {/* Display selected files */}
+          {files.length > 0 && (
+            <ul className="mt-3 space-y-2 text-sm">
+              {files.map((file, index) => (
+                <li key={index} className="flex justify-between items-center border-b pb-1">
+                  <span>{file.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveFile(index)}
+                    className="text-red-500 hover:underline text-xs"
+                  >
+                    Remove
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
 
       <div className="flex justify-end gap-4 pt-2">


### PR DESCRIPTION
# Support editing blog post tags (backend and frontend)

## Summary

This PR implements full support for editing blog post title, content, and tags on both the backend and frontend. Users can now edit their posts directly from the UI.

## Key Changes

### Backend Changes

- **Enable Tag Updates for Existing Blog Posts**
  - The `/api/blog-posts/update` endpoint now supports updating tags in addition to title and content.
  - Tags are accepted as multiple `tags` fields in `multipart/form-data`, similar to the create post flow.

- **Updated BlogPostServiceImpl**
  - Modified the `updateBlogPost` method to handle tag changes.
  
### Frontend Changes

- **UI Support for Editing Blog Posts**
  - Editing allows modifying the title, content, and tags, but **image updates are hidden** during edit mode.
  - A conditional UI ensures the file upload field only appears when creating a new post, not when editing.

- **Updated `BlogContainer.tsx`**
  - Integrated `useUpdateBlogPost` mutation using `FormData` to send title, content, and tags as `multipart/form-data`.
  - Query invalidation ensures the posts list refreshes after successful updates.

- **Updated `useUpdateBlogPost` Hook**
  - Switched to sending a `FormData` payload to handle tags properly.
  - Ensured multiple `tags` fields are appended for compatibility with backend expectations.

### API Expectations

- Update requests must send:
  - `postId`
  - `title`
  - `content`
  - (Optional) Multiple `tags` fields

## Screenshots

API testing through postman
![image](https://github.com/user-attachments/assets/a21f6919-5d35-40c5-9046-44154398d65a)

Edit form with hidden file upload section
![image](https://github.com/user-attachments/assets/472ccbf7-a1a5-42a8-96e7-cf6a1585ffa1)

Closes #560
