### PR TITLE
bugfix: #562 minor UI defects and missing elements

### DIFF
--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -420,12 +420,12 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
   
         {/* Image stack */}
         {imageUrls.length > 0 && (
-          <div className="relative w-full md:w-[300px] h-[300px] mb-2 md:mb-0 shrink-0">
+          <div className="relative w-full md:w-[250px] h-[250px] mb-2 md:mb-0 shrink-0">
             {imageUrls.slice(0, 3).map((url, index) => (
               <div
                 key={index}
                 onClick={() => handleImageClick(index)}
-                className="absolute top-0 left-0 w-[280px] h-[280px] rounded-md overflow-hidden cursor-pointer border transition-transform"
+                className="absolute top-0 left-0 w-[230px] h-[230px] rounded-md overflow-hidden cursor-pointer border transition-transform"
                 style={{
                   transform: `translate(${index * 10}px, ${index * 10}px)`,
                   zIndex: 10 - index,

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -420,12 +420,12 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
   
         {/* Image stack */}
         {imageUrls.length > 0 && (
-          <div className="relative w-full md:w-[200px] h-[200px] mb-2 md:mb-0 shrink-0">
+          <div className="relative w-full md:w-[300px] h-[300px] mb-2 md:mb-0 shrink-0">
             {imageUrls.slice(0, 3).map((url, index) => (
               <div
                 key={index}
                 onClick={() => handleImageClick(index)}
-                className="absolute top-0 left-0 w-[180px] h-[180px] rounded-md overflow-hidden cursor-pointer border transition-transform"
+                className="absolute top-0 left-0 w-[280px] h-[280px] rounded-md overflow-hidden cursor-pointer border transition-transform"
                 style={{
                   transform: `translate(${index * 10}px, ${index * 10}px)`,
                   zIndex: 10 - index,
@@ -453,9 +453,9 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
           <div className="relative w-3/4 h-3/4 bg-zinc-800 rounded-md overflow-hidden">
             <button
               onClick={closeFullScreen}
-              className="absolute text-2xl top-4 right-4 text-white px-3 py-2 rounded-md hover:bg-red-600 transition"
+              className="absolute text-4xl w-10 h-10 top-4 right-4 text-white -px-3rounded-md hover:text-red-600 transition"
             >
-              &#128473;
+              ×
             </button>
             <img
               src={imageUrls[currentImageIndex]}
@@ -464,17 +464,17 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
             />
             <button
               onClick={prevImage}
-              className="absolute text-6xl left-4 top-1/2 transform -translate-y-1/2 text-white px-3 pb-3 rounded-md hover:bg-gray-500 transition"
+              className="absolute text-6xl left-4 top-1/2 transform -translate-y-1/2 text-white px-3 pb-3 rounded-md hover:text-blue-500 transition"
             >
               &#8249;
             </button>
             <button
               onClick={nextImage}
-              className="absolute text-6xl right-4 top-1/2 transform -translate-y-1/2 text-white px-3 pb-3 rounded-md hover:bg-gray-500 transition"
+              className="absolute text-6xl right-4 top-1/2 transform -translate-y-1/2 text-white px-3 pb-3 rounded-md hover:text-blue-500 transition"
             >
               &#8250;
             </button>
-            <div className="absolute text-xl bottom-4 left-1/2 transform -translate-x-1/2 bg-slate-400 bg-opacity-50 text-white px-3 py-1 rounded-md text-sm font-medium">
+            <div className="absolute text-xl bottom-4 left-1/2 transform -translate-x-1/2 bg-b100 bg-opacity-50 text-white px-3 py-1 rounded-md text-sm font-medium">
               {currentImageIndex + 1} / {imageUrls.length}
             </div>
           </div>

--- a/quolance-ui/src/components/ui/blog/UserSummary.tsx
+++ b/quolance-ui/src/components/ui/blog/UserSummary.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { FreelancerProfileType } from '@/models/user/UserResponse';
 import FreelancerDefaultIcon from '@/public/images/freelancer_default_icon.png';
+import Link from 'next/link';
 
 const UserSummary: React.FC<{ user: FreelancerProfileType }> = ({ user }) => {
   return (
@@ -15,13 +16,13 @@ const UserSummary: React.FC<{ user: FreelancerProfileType }> = ({ user }) => {
       className="w-96 rounded-2xl bg-gradient-to-r from-blue-50 via-white to-indigo-50 p-6 shadow-xl border border-gray-100 text-center"
     >
 
-      <div className="flex justify-center -mt-16 mb-4">
+      <div className="flex justify-center -mt-24 mb-4">
         <Image
           alt={`${user.firstName} ${user.lastName}'s profile`}
           src={user.profileImageUrl || FreelancerDefaultIcon}
-          width={96}
-          height={96}
-          className="w-24 h-24 rounded-full border-4 border-indigo-200 shadow-md object-cover"
+          width={120}
+          height={120}
+          className="w-36 h-36 rounded-full border-4 border-indigo-200 shadow-md object-cover"
         />
       </div>
 
@@ -46,7 +47,13 @@ const UserSummary: React.FC<{ user: FreelancerProfileType }> = ({ user }) => {
         </div>
       </div>
 
-      <p className="text-sm text-gray-700 italic mb-4">{user.bio || 'No bio provided.'}</p>
+      <p className="text-sm text-gray-700 italic mb-4 line-clamp-6">{user.bio || 'No bio provided.'}</p>
+      <Link 
+        href={`/public-profile/${user.username}`}
+        className="text-blue-600 hover:text-blue-800 text-sm font-medium underline underline-offset-4 transition"
+      >
+        view {user.firstName}'s profile
+      </Link>
 
       {user.skills.length > 0 && (
         <div className="flex flex-wrap justify-center gap-2">

--- a/quolance-ui/src/components/ui/blog/UserSummary.tsx
+++ b/quolance-ui/src/components/ui/blog/UserSummary.tsx
@@ -16,13 +16,13 @@ const UserSummary: React.FC<{ user: FreelancerProfileType }> = ({ user }) => {
       className="w-96 rounded-2xl bg-gradient-to-r from-blue-50 via-white to-indigo-50 p-6 shadow-xl border border-gray-100 text-center"
     >
 
-      <div className="flex justify-center -mt-24 mb-4">
+      <div className="flex justify-center -mt-20 mb-4">
         <Image
           alt={`${user.firstName} ${user.lastName}'s profile`}
           src={user.profileImageUrl || FreelancerDefaultIcon}
           width={120}
           height={120}
-          className="w-36 h-36 rounded-full border-4 border-indigo-200 shadow-md object-cover"
+          className="w-28 h-28 rounded-full border-4 border-indigo-200 shadow-md object-cover"
         />
       </div>
 


### PR DESCRIPTION
# Minor UI Defects and Missing Elements Fix

## Summary
This PR addresses minor UI inconsistencies and missing elements identified in **BUG #562** to improve the overall visual consistency and functionality of the blog and user experience.

## Key Changes

### UserSummary Card Improvements
- Enlarged profile picture for better clarity and visibility.
- Added a clickable link to view the user's full public profile.
- Capped the user bio to six lines to prevent layout overflow with long bios.

### PostCard and Fullscreen Viewer Updates
- Resized the image preview stack for better visibility and aesthetic balance.
- Replaced the fullscreen viewer close (X), previous (<), and next (>) characters with more reliable and properly aligned alternatives.
- Updated hover effects for fullscreen viewer controls to improve usability and consistency.
- Adjusted the background colour of the image index at the bottom of the fullscreen viewer for better readability.

## Screenshots
### Resizing of the image preview stack
From:
![image](https://github.com/user-attachments/assets/fc4a4931-a40a-4749-be8b-6223f818441c)
To:
![image](https://github.com/user-attachments/assets/d3c340ff-fd4d-4e07-8499-956a52ea527e)

### Hover styling change + (x) character change
From:
![image](https://github.com/user-attachments/assets/d3ff053a-97ae-4688-a8f0-96e36bc92916)
![image](https://github.com/user-attachments/assets/01a9383b-4535-4755-82e0-d045f087b296)
To:
![image](https://github.com/user-attachments/assets/8289a400-3352-49f0-a140-753456407859) 
![image](https://github.com/user-attachments/assets/b841275e-c411-4cb9-8b26-20e928def788)

### User bio line capping + link to public profile
From:
![image](https://github.com/user-attachments/assets/7be6c331-8df3-479d-9b9e-7adc81d14cd2)
To:
![image](https://github.com/user-attachments/assets/4beb19ea-e418-4f45-a57b-1f83a4dc7f6a)




## Closes
Closes #562
