### PR TITLE
refactor: #566 Refactored blog

### DIFF
--- a/quolance-ui/src/api/blog-api.ts
+++ b/quolance-ui/src/api/blog-api.ts
@@ -1,20 +1,12 @@
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
 import httpClient from '@/lib/httpClient';
-import { BlogPostViewType } from '@/constants/types/blog-types';
+import { BlogPostUpdateDto, BlogPostViewType, CommentRequestDto, CommentResponseDto, ReactionRequestDto, ReactionResponseDto } from '@/constants/types/blog-types';
 import { HttpErrorResponse } from '@/models/http/HttpErrorResponse';
 import { PagedResponse } from '@/models/http/PagedResponse';
 import { PaginationParams } from '@/constants/types/pagination-types';
 import { queryToString } from '@/util/stringUtils';
 
 /* ---------- Blog Posts ---------- */
-export interface BlogPostUpdateDto {
-  postId: string;
-  title: string;
-  content: string;
-  // tags: string[];
-  // files?: File[];
-}
-
 export const useCreateBlogPost = (options?: {
   onSuccess?: () => void;
   onError?: (error: unknown) => void;
@@ -100,17 +92,6 @@ export const useDeleteBlogPost = (options?: {
 };
 
 /* ---------- Blog Comments ---------- */
-export interface CommentResponseDto {
-  commentId: string;
-  blogPostId: string;
-  username: string;
-  content: string;
-}
-
-export interface CommentRequestDto {
-  content: string;
-}
-
 export const useGetCommentsByPostId = (
   postId: string,
   pagination: PaginationParams,
@@ -186,19 +167,6 @@ export const useUpdateComment = (options?: {
 };
 
 /* ---------- Blog Reactions ---------- */
-export interface ReactionResponseDto {
-  id: string;
-  reactionType: string;
-  userId: string;
-  userName: string;
-  blogPostId: string;
-}
-
-export interface ReactionRequestDto {
-  reactionType: string;
-  blogPostId: string;
-}
-
 export const useGetReactionsByPostId = (
   postId: string,
   options?: {

--- a/quolance-ui/src/components/ui/blog/CommentCard.tsx
+++ b/quolance-ui/src/components/ui/blog/CommentCard.tsx
@@ -110,6 +110,7 @@ const CommentCard: React.FC<CommentCardProps> = ({
               value={editedContent}
               onChange={(e) => setEditedContent(e.target.value)}
               className="w-full p-2 border rounded-md mt-2 text-sm"
+              placeholder="Edit you comment..."
             />
           ):(
             <p className="text-sm text-gray-700 mt-1 break-all overflow-hidden w-full">

--- a/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
+++ b/quolance-ui/src/components/ui/blog/CreatePostModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 interface CreatePostModalProps {
     open: boolean;

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -99,6 +99,12 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
 
   const isUserSummaryOpen = openUserSummaryPostId === id;
 
+  const translateClasses = [
+    'translate-x-4 translate-y-4',
+    'translate-x-2 translate-y-2',
+    'translate-x-0 translate-y-0',
+  ];
+
   useEffect(() => {
     if (pagedComments?.content) {
       setAllLoadedComments((prevComments) => {
@@ -400,24 +406,22 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
         {/* Image stack */}
         {imageUrls.length > 0 && (
           <div className="relative w-full md:w-[250px] h-[250px] mb-2 md:mb-0 shrink-0">
-            {imageUrls.slice(0, 3).map((url, index) => (
+            {imageUrls.slice(0, 3).reverse().map((url, index) => (
               <div
                 key={index}
                 onClick={() => handleImageClick(index)}
-                className="absolute top-0 left-0 w-[230px] h-[230px] rounded-md overflow-hidden cursor-pointer border transition-transform"
-                style={{
-                  transform: `translate(${index * 10}px, ${index * 10}px)`,
-                  zIndex: 10 - index,
-                }}
+                className={`absolute top-0 left-0 w-[230px] h-[230px] rounded-md overflow-hidden cursor-pointer border transition-transform ${translateClasses[index]} z-[${10 - index}]`}
               >
                 <img
                   src={url}
                   alt={`Post image ${index + 1}`}
                   className="w-full h-full object-cover"
                 />
+
                 {index === 2 && imageUrls.length > 3 && (
-                  <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center text-white text-sm font-semibold">
-                    +{imageUrls.length - 3}
+                  <div className="absolute inset-0 bg-black bg-opacity-50 flex flex-col items-center justify-center text-white font-semibold rounded-md">
+                    <span className="text-2xl">{imageUrls.length}+</span>
+                    <span className="text-xs mt-1">more</span>
                   </div>
                 )}
               </div>

--- a/quolance-ui/src/components/ui/blog/PostCard.tsx
+++ b/quolance-ui/src/components/ui/blog/PostCard.tsx
@@ -10,7 +10,6 @@ import CommentCard from "./CommentCard";
 import {useGetFreelancerProfile} from "@/api/freelancer-api";
 import UserSummary from "@/components/ui/blog/UserSummary";
 import {
-  CommentResponseDto,
   useAddComment,
   useDeleteBlogPost,
   useGetCommentsByPostId,
@@ -19,6 +18,7 @@ import {
   useRemoveReaction,
   useReportBlogPost
 } from "@/api/blog-api";
+import { CommentResponseDto } from "@/constants/types/blog-types";
 import {showToast} from "@/util/context/ToastProvider";
 import { PaginationParams } from "@/constants/types/pagination-types";
 import { Button } from "../button";
@@ -62,7 +62,6 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [editingPost, setEditingPost] = useState<PostCardProps | null>(null);
 
-  const [userSummaryPosition, setUserSummaryPosition] = useState<{ x: number; y: number } | null>(null);
   const [pagination, setPagination] = useState<PaginationParams>({page: 0, size: 5});
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -146,7 +145,6 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
         !authorNameRef.current.contains(event.target as Node)
       ) {
         setOpenUserSummaryPostId(null);
-        setUserSummaryPosition(null);
       }
     }
 
@@ -229,14 +227,7 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
   const handleShowUserSummary = (event: React.MouseEvent<HTMLElement>) => {
     if (isUserSummaryOpen) {
       setOpenUserSummaryPostId(null);
-      setUserSummaryPosition(null);
     } else {
-      const rect = event.currentTarget.getBoundingClientRect();
-
-      setUserSummaryPosition({
-        x: rect.left - 25 + window.scrollX,
-        y: rect.top - 50 + window.scrollY
-      });
       setOpenUserSummaryPostId(id);
     }
   };
@@ -299,43 +290,31 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
     <div className="bg-white bg-opacity-60 shadow-md rounded-md font-sans p-8">
       {/* User Info + Top Row */}
       <div className="flex justify-between items-start">
-        <div className="flex items-center">
-          <Image
-            ref={profileImageRef}
-            alt={`${authorName}'s profile`}
-            src={authorProfile?.profileImageUrl || icon}
-            width={56}
-            height={56}
-            className="w-14 h-14 rounded-full object-cover cursor-pointer"
+        <div className="relative inline-block">
+          <button
+            ref={authorNameRef}
+            className="flex items-center space-x-2"
             onClick={handleShowUserSummary}
-          />
-          <div className="ml-4">
-            <button
-              ref={authorNameRef}
-              className="text-gray-800 text-lg font-bold cursor-pointer focus:outline-none"
-              onClick={handleShowUserSummary}
-            >
-              {authorName}
-            </button>
-            <div className="text-sm text-gray-500">
-              {new Intl.DateTimeFormat("en-US", {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              }).format(new Date(dateCreated))}
-            </div>
-          </div>
-          {isUserSummaryOpen && userSummaryPosition && (
+          >
+            <Image
+              ref={profileImageRef}
+              src={authorProfile?.profileImageUrl || icon}
+              alt="User Profile"
+              width={56}
+              height={56}
+              className="w-14 h-14 rounded-full object-cover"
+            />
+            <span className="font-semibold text-gray-800">{authorName}</span>
+          </button>
+
+          {isUserSummaryOpen && authorProfile && (
             <div
-              ref={userSummaryRef}
-              className="absolute z-50"
-              style={{
-                top: userSummaryPosition.y,
-                left: userSummaryPosition.x,
-              }}
-            >
-              {authorProfile && <UserSummary user={authorProfile} />}
-            </div>
+            ref={userSummaryRef}
+            className="absolute z-50 -translate-x-4 translate-y-4 md:translate-x-4 md:translate-y-1"
+          >
+            <UserSummary user={authorProfile} />
+          </div>
+          
           )}
         </div>
   
@@ -474,7 +453,7 @@ const PostCard: React.FC<PostCardProps> = ({ id, title, content, authorName, dat
             >
               &#8250;
             </button>
-            <div className="absolute text-xl bottom-4 left-1/2 transform -translate-x-1/2 bg-b100 bg-opacity-50 text-white px-3 py-1 rounded-md text-sm font-medium">
+            <div className="absolute text-xl bottom-4 left-1/2 transform -translate-x-1/2 bg-b100 bg-opacity-50 text-white px-3 py-1 rounded-md font-medium">
               {currentImageIndex + 1} / {imageUrls.length}
             </div>
           </div>

--- a/quolance-ui/src/constants/types/blog-types.ts
+++ b/quolance-ui/src/constants/types/blog-types.ts
@@ -37,8 +37,7 @@ export interface BlogPostUpdateDto {
     postId: string;
     title: string;
     content: string;
-    // tags: string[];
-    // files?: File[];
+    tags: string[];
   }
 
   export interface ReactionResponseDto {

--- a/quolance-ui/src/constants/types/blog-types.ts
+++ b/quolance-ui/src/constants/types/blog-types.ts
@@ -11,6 +11,8 @@ export type BlogPostType = {
     title: string;
     content: string;
     userId: string;
+    tags: string[];
+    files?: File[];
 };
 
 export type CommentType = {

--- a/quolance-ui/src/constants/types/blog-types.ts
+++ b/quolance-ui/src/constants/types/blog-types.ts
@@ -19,3 +19,35 @@ export type CommentType = {
     content: string;
     dateCreated: string;
 }
+
+export interface CommentResponseDto {
+    commentId: string;
+    blogPostId: string;
+    username: string;
+    content: string;
+  }
+  
+export interface CommentRequestDto {
+content: string;
+}
+
+export interface BlogPostUpdateDto {
+    postId: string;
+    title: string;
+    content: string;
+    // tags: string[];
+    // files?: File[];
+  }
+
+  export interface ReactionResponseDto {
+    id: string;
+    reactionType: string;
+    userId: string;
+    userName: string;
+    blogPostId: string;
+  }
+  
+  export interface ReactionRequestDto {
+    reactionType: string;
+    blogPostId: string;
+  }


### PR DESCRIPTION
- Moved blog-related types and DTOs from `/api/blog-api.tsx` to `constants/types/blog-types.ts` to align with Release 2 structural guidelines.
- Replaced dynamic inline styles for UserSummary positioning with TailwindCSS utility classes.
- Removed inline styles from blog post image stack; used TailwindCSS classes for consistent, maintainable styling.

Closes #566