### PR TITLE
#568-BE-Add integration tests related to blogpost feature (post, comment, reations)

### DIFF
--- a/quolance-api/src/main/java/com/quolance/quolance_api/controllers/blog/BlogCommentController.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/controllers/blog/BlogCommentController.java
@@ -44,7 +44,7 @@ public class BlogCommentController {
 
     @PutMapping("/{id}")
     @Operation(summary = "Update a blog comment")
-    public ResponseEntity<BlogCommentDto> updateBlogComment(@PathVariable UUID id, @RequestBody BlogCommentDto request) {
+    public ResponseEntity<BlogCommentDto> updateBlogComment(@PathVariable UUID id, @Valid @RequestBody BlogCommentDto request) {
         User author = SecurityUtil.getAuthenticatedUser();
         log.info("User {} is updating comment {}", author.getId(), id);
         BlogCommentDto response = blogCommentService.updateBlogComment(id, request, author);

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogCommentDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/BlogCommentDto.java
@@ -1,6 +1,8 @@
 package com.quolance.quolance_api.dtos.blog;
 
 import com.quolance.quolance_api.entities.blog.BlogComment;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +20,7 @@ public class BlogCommentDto {
     private UUID blogPostId;
     private UUID userId;
     private String username;
+    @NotBlank(message = "Content cannot be blank")
     private String content;
 
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/ReactionRequestDto.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/dtos/blog/ReactionRequestDto.java
@@ -3,6 +3,8 @@ package com.quolance.quolance_api.dtos.blog;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.quolance.quolance_api.entities.blog.Reaction;
 import com.quolance.quolance_api.entities.enums.ReactionType;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +20,7 @@ import java.util.UUID;
 public class ReactionRequestDto {
 
     @JsonProperty("reactionType")
+    @NotNull(message = "Reaction type is required")
     private ReactionType reactionType; 
 
     @JsonProperty("blogPostId")

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogCommentServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogCommentServiceImpl.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.util.List;
 import java.util.UUID;
@@ -54,7 +56,7 @@ public class BlogCommentServiceImpl implements BlogCommentService {
         if (!isAuthorOfPost(blogComment, author)) {
             log.warn("User ID: {} attempted to update a comment they do not own (comment ID: {})", author.getId(),
                     commentId);
-            throw new ApiException("You cannot update a comment that does not belong to you.");
+                    throw new AccessDeniedException("You cannot update a comment that does not belong to you.");
         }
 
         blogComment.setContent(blogCommentDto.getContent());
@@ -70,7 +72,7 @@ public class BlogCommentServiceImpl implements BlogCommentService {
 
         if (!isAuthorOfPost(blogComment, author)) {
             log.warn("User ID: {} attempted to delete a comment they do not own (comment ID: {})", author.getId(),commentId);
-            throw new ApiException("You cannot delete a comment that does not belong to you.");
+            throw new AccessDeniedException("You cannot delete a comment that does not belong to you.");
         }
 
         blogCommentRepository.delete(blogComment);

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/BlogPostServiceImpl.java
@@ -95,7 +95,10 @@ public class BlogPostServiceImpl implements BlogPostService {
         BlogPost blogPost = getBlogPostEntity(request.getPostId());
         if (!isAuthorOfPost(blogPost, author)) {
             log.warn("User {} attempted to edit a blog post they do not own", author.getId());
-            throw new ApiException("You cannot edit a project that does not belong to you.");
+            throw ApiException.builder()
+                .status(HttpServletResponse.SC_FORBIDDEN)
+                .message("You cannot edit a blog post that does not belong to you.")
+                .build();
         }
         BlogPost updated = updateBlogPost(request, blogPost);
         blogPostRepository.save(updated);
@@ -110,7 +113,10 @@ public class BlogPostServiceImpl implements BlogPostService {
 
         if (!isAuthorOfPost(blogPost, author)) {
             log.warn("User {} attempted to delete a blog post they do not own", author.getId());
-            throw new ApiException("You cannot delete a project that does not belong to you.");
+            throw ApiException.builder()
+                .status(HttpServletResponse.SC_FORBIDDEN)
+                .message("You cannot delete a blog post that does not belong to you.")
+                .build();
         }
         blogPostRepository.deleteById(id);
         log.info("Blog post deleted successfully");

--- a/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/ReactionServiceImpl.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/services/entity_services/impl/blog/ReactionServiceImpl.java
@@ -40,7 +40,6 @@ public class ReactionServiceImpl implements ReactionService {
             throw new ApiException("BlogPostId must be provided for reacting to a post.");
         }
 
-        validateReactionType(requestDto.getReactionType());
 
         BlogPost blogPost = blogPostService.getBlogPostEntity(requestDto.getBlogPostId());
 

--- a/quolance-api/src/main/java/com/quolance/quolance_api/util/exceptions/GlobalExceptionHandler.java
+++ b/quolance-api/src/main/java/com/quolance/quolance_api/util/exceptions/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.quolance.quolance_api.util.exceptions;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.springframework.http.HttpHeaders;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,7 +28,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
-                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+            HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         Map<String, String> errors = new HashMap<>();
         List<String> generalErrors = new ArrayList<>();
         ex.getBindingResult().getAllErrors().forEach(error -> {
@@ -93,5 +95,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         response.put("status", HttpStatus.BAD_REQUEST.value());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
-}
 
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<HttpErrorResponse> handleAccessDenied(AccessDeniedException e) {
+        log.info("Handling AccessDeniedException: {}", e.getMessage());
+        var response = HttpErrorResponse.of(e.getMessage(), 403, null, null);
+        return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<HttpErrorResponse> handleEntityNotFound(EntityNotFoundException e) {
+        log.info("Entity not found: {}", e.getMessage());
+        HttpErrorResponse response = HttpErrorResponse.of(e.getMessage(), 404, null, null);
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+}

--- a/quolance-api/src/test/java/com/quolance/quolance_api/integration/tests/BlogReactionsControllerIntegrationTest.java
+++ b/quolance-api/src/test/java/com/quolance/quolance_api/integration/tests/BlogReactionsControllerIntegrationTest.java
@@ -22,130 +22,175 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.UUID;
+
 @ActiveProfiles("test")
 class BlogReactionsControllerIntegrationTest extends BaseIntegrationTest {
 
-    @Autowired
-    private ReactionRepository reactionRepository;
+        @Autowired
+        private ReactionRepository reactionRepository;
 
-    @Autowired
-    private BlogPostRepository blogPostRepository;
+        @Autowired
+        private BlogPostRepository blogPostRepository;
 
-    @Autowired
-    private BlogCommentRepository blogCommentRepository;
+        @Autowired
+        private BlogCommentRepository blogCommentRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+        @Autowired
+        private UserRepository userRepository;
 
-    private User loggedInUser;
-    private BlogPost blogPost;
-    private BlogComment blogComment;
+        private User loggedInUser;
+        private BlogPost blogPost;
+        private BlogComment blogComment;
 
-    @BeforeEach
-    void setUp() throws Exception {
-        reactionRepository.deleteAll();
-        blogCommentRepository.deleteAll();
-        blogPostRepository.deleteAll();
-        userRepository.deleteAll();
+        @BeforeEach
+        void setUp() throws Exception {
+                reactionRepository.deleteAll();
+                blogCommentRepository.deleteAll();
+                blogPostRepository.deleteAll();
+                userRepository.deleteAll();
 
-        loggedInUser = userRepository.save(EntityCreationHelper.createClient());
-        blogPost = blogPostRepository.save(EntityCreationHelper.createBlogPost(loggedInUser));
-        blogComment = blogCommentRepository.save(EntityCreationHelper.createBlogComment(loggedInUser, blogPost));
+                loggedInUser = userRepository.save(EntityCreationHelper.createClient());
+                blogPost = blogPostRepository.save(EntityCreationHelper.createBlogPost(loggedInUser));
+                blogComment = blogCommentRepository
+                                .save(EntityCreationHelper.createBlogComment(loggedInUser, blogPost));
 
-        session = sessionCreationHelper.getSession("client@test.com", "Password123!");
+                session = sessionCreationHelper.getSession("client@test.com", "Password123!");
 
-    }
+        }
 
-    @Test
-    void testReactToPost() throws Exception {
-        ReactionRequestDto requestDto = new ReactionRequestDto();
-        requestDto.setReactionType(ReactionType.LIKE);
-        requestDto.setBlogPostId(blogPost.getId());
+        @Test
+        void testReactToPost() throws Exception {
+                ReactionRequestDto requestDto = new ReactionRequestDto();
+                requestDto.setReactionType(ReactionType.LIKE);
+                requestDto.setBlogPostId(blogPost.getId());
 
-        mockMvc.perform(post("/api/blog-posts/reactions/post")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto))
-                        .session(session))
-                .andExpect(status().isOk());
-    }
+                mockMvc.perform(post("/api/blog-posts/reactions/post")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestDto))
+                                .session(session))
+                                .andExpect(status().isOk());
+        }
 
-    @Test
-    void testReactToComment() throws Exception {
-        ReactionRequestDto requestDto = new ReactionRequestDto();
-        requestDto.setReactionType(ReactionType.LIKE);
-        requestDto.setBlogCommentId(blogComment.getId());
+        @Test
+        void testReactToComment() throws Exception {
+                ReactionRequestDto requestDto = new ReactionRequestDto();
+                requestDto.setReactionType(ReactionType.LIKE);
+                requestDto.setBlogCommentId(blogComment.getId());
 
-        mockMvc.perform(post("/api/blog-posts/reactions/comment")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto))
-                        .session(session))
-                .andExpect(status().isOk());
-    }
+                mockMvc.perform(post("/api/blog-posts/reactions/comment")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestDto))
+                                .session(session))
+                                .andExpect(status().isOk());
+        }
 
-    @Test
-    void testGetReactionsByPost() throws Exception {
-        reactionRepository.save(
-                Reaction.builder()
-                        .reactionType(ReactionType.LIKE)
-                        .blogPost(blogPost)
-                        .user(loggedInUser)
-                        .build()
-        );
+        @Test
+        void testGetReactionsByPost() throws Exception {
+                reactionRepository.save(
+                                Reaction.builder()
+                                                .reactionType(ReactionType.LIKE)
+                                                .blogPost(blogPost)
+                                                .user(loggedInUser)
+                                                .build());
 
-        mockMvc.perform(get("/api/blog-posts/reactions/post/" + blogPost.getId())
-                        .session(session)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
-    }
+                mockMvc.perform(get("/api/blog-posts/reactions/post/" + blogPost.getId())
+                                .session(session)
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk());
+        }
 
-    @Test
-    void testGetReactionsByComment() throws Exception {
-        reactionRepository.save(
-                Reaction.builder()
-                        .reactionType(ReactionType.LIKE)
-                        .blogComment(blogComment)
-                        .user(loggedInUser)
-                        .build()
-        );
+        @Test
+        void testGetReactionsByComment() throws Exception {
+                reactionRepository.save(
+                                Reaction.builder()
+                                                .reactionType(ReactionType.LIKE)
+                                                .blogComment(blogComment)
+                                                .user(loggedInUser)
+                                                .build());
 
-        mockMvc.perform(get("/api/blog-posts/reactions/comment/" + blogComment.getId())
-                        .session(session)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
-    }
+                mockMvc.perform(get("/api/blog-posts/reactions/comment/" + blogComment.getId())
+                                .session(session)
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk());
+        }
 
-    @Test
-    void testDeleteReactionByOwner() throws Exception {
-        Reaction reaction = reactionRepository.save(
-                Reaction.builder()
-                        .reactionType(ReactionType.LIKE)
-                        .blogPost(blogPost)
-                        .user(loggedInUser)
-                        .build()
-        );
+        @Test
+        void testDeleteReactionByOwner() throws Exception {
+                Reaction reaction = reactionRepository.save(
+                                Reaction.builder()
+                                                .reactionType(ReactionType.LIKE)
+                                                .blogPost(blogPost)
+                                                .user(loggedInUser)
+                                                .build());
 
-        mockMvc.perform(delete("/api/blog-posts/reactions/" + reaction.getId())
-                        .session(session)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                mockMvc.perform(delete("/api/blog-posts/reactions/" + reaction.getId())
+                                .session(session)
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk());
 
-        assertThat(reactionRepository.findById(reaction.getId())).isEmpty();
-    }
+                assertThat(reactionRepository.findById(reaction.getId())).isEmpty();
+        }
 
-    @Test
-    void testDeleteReactionNotOwner() throws Exception {
-        User anotherUser = userRepository.save(EntityCreationHelper.createFreelancer(0));
-        Reaction reaction = reactionRepository.save(
-                Reaction.builder()
-                        .reactionType(ReactionType.LIKE)
-                        .blogPost(blogPost)
-                        .user(anotherUser)
-                        .build()
-        );
+        @Test
+        void testDeleteReactionNotOwner() throws Exception {
+                User anotherUser = userRepository.save(EntityCreationHelper.createFreelancer(0));
+                Reaction reaction = reactionRepository.save(
+                                Reaction.builder()
+                                                .reactionType(ReactionType.LIKE)
+                                                .blogPost(blogPost)
+                                                .user(anotherUser)
+                                                .build());
 
-        mockMvc.perform(delete("/api/blog-posts/reactions/" + reaction.getId())
-                        .session(session)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden());
-    }
+                mockMvc.perform(delete("/api/blog-posts/reactions/" + reaction.getId())
+                                .session(session)
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void testReactToPost_Unauthenticated_ShouldReturn401() throws Exception {
+                ReactionRequestDto dto = new ReactionRequestDto();
+                dto.setReactionType(ReactionType.LIKE);
+                dto.setBlogPostId(blogPost.getId());
+
+                mockMvc.perform(post("/api/blog-posts/reactions/post")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
+                                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void testReactToPost_MissingReactionType_ShouldReturn422() throws Exception {
+                ReactionRequestDto dto = new ReactionRequestDto();
+                dto.setBlogPostId(blogPost.getId());
+
+                mockMvc.perform(post("/api/blog-posts/reactions/post")
+                                .session(session)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
+                                .andExpect(status().isUnprocessableEntity());
+        }
+
+        @Test
+        void testReactToNonexistentPost_ShouldReturn404() throws Exception {
+                ReactionRequestDto dto = new ReactionRequestDto();
+                dto.setReactionType(ReactionType.LIKE);
+                dto.setBlogPostId(UUID.randomUUID());
+
+                mockMvc.perform(post("/api/blog-posts/reactions/post")
+                                .session(session)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(dto)))
+                                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void testDeleteNonexistentReaction_ShouldReturn404() throws Exception {
+                mockMvc.perform(delete("/api/blog-posts/reactions/" + UUID.randomUUID())
+                                .session(session)
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isNotFound());
+        }
+
 }


### PR DESCRIPTION
Added new tests for the post, reactions as well as comments: 

-tests to cover authentication of user
-tests to cover non-existent entities (reaction to non-existent comment)
-test to cover authorization (deleting another user's post)
-etc